### PR TITLE
feat(pr-relations): change create pr relation command for a service

### DIFF
--- a/app/observers/pull_request_observer.rb
+++ b/app/observers/pull_request_observer.rb
@@ -3,9 +3,13 @@ class PullRequestObserver < PowerTypes::Observer
   before_destroy :destroy_pull_request_relations
 
   def update_pull_request_relations
-    if object.saved_change_to_merged_by_id? ||
-        object.saved_change_to_last_pull_req_review_modification?
-      CreatePullRelations.for(pull_request: object)
+    if object.saved_change_to_merged_by_id?
+      service = PullRequestRelationService.new(pull_request: object)
+      service.create_merge_relation
+    end
+    if object.saved_change_to_last_pull_req_review_modification?
+      service = PullRequestRelationService.new(pull_request: object)
+      service.create_review_relations
     end
   end
 

--- a/app/services/pull_request_relation_service.rb
+++ b/app/services/pull_request_relation_service.rb
@@ -1,14 +1,7 @@
-class CreatePullRelations < PowerTypes::Command.new(:pull_request)
-  def perform
-    creates_from_merge_info
-    creates_from_reviews
-  end
-
-  private
-
-  def creates_from_merge_info
-    if @pull_request.merged_by.present? &&
-        PullRequestRelation.by_pull_request(@pull_request.id).merged_relations.empty?
+class PullRequestRelationService < PowerTypes::Service.new(:pull_request)
+  def create_merge_relation
+    if @pull_request.merged_by.present?
+      PullRequestRelation.merged_relations.by_pull_request(@pull_request.id).destroy_all
       PullRequestRelation.merged_relations.create!(
         pull_request: @pull_request,
         github_user: @pull_request.merged_by,
@@ -19,9 +12,9 @@ class CreatePullRelations < PowerTypes::Command.new(:pull_request)
     end
   end
 
-  def creates_from_reviews
+  def create_review_relations
     if @pull_request.pull_request_reviews.present?
-      PullRequestRelation.by_pull_request(@pull_request.id).destroy_all
+      PullRequestRelation.review_relations.by_pull_request(@pull_request.id).destroy_all
       last_review_for_each_user.each do |review|
         PullRequestRelation.review_relations.create!(
           pull_request: @pull_request,
@@ -33,6 +26,8 @@ class CreatePullRelations < PowerTypes::Command.new(:pull_request)
       end
     end
   end
+
+  private
 
   def last_review_for_each_user
     reviews_by_users = @pull_request.pull_request_reviews.group_by(&:github_user_id)

--- a/spec/observers/pull_request_observer_spec.rb
+++ b/spec/observers/pull_request_observer_spec.rb
@@ -2,19 +2,23 @@ require 'rails_helper'
 
 describe PullRequestObserver, observers: true do
   describe "#update_pull_request_relations" do
-    before do
-      expect(CreatePullRelations).to receive(:for).and_return(nil)
-    end
-
     context "when merge data is saved" do
       let(:pull_request) { create(:pull_request) }
+      before do
+        expect_any_instance_of(PullRequestRelationService).to receive(:create_merge_relation)
+          .and_return(nil)
+      end
 
-      it "calls CreatePullRelations" do
+      it "calls service to create merge relation" do
         pull_request.update(merged_by: create(:github_user), gh_merged_at: Time.current)
       end
     end
 
     context "when review data is saved" do
+      before do
+        expect_any_instance_of(PullRequestRelationService).to receive(:create_review_relations)
+          .and_return(nil)
+      end
       it "calls CreatePullRelations" do
         create(:pull_request_with_reviews, reviews_count: 1)
       end


### PR DESCRIPTION
Cada vez que se creaban las relaciones de un PR (pull request), solo se creaban un tipo de relación (`merged_by` o `reviewer`). El problema estaba en que el método que creaba las relaciones de review (`creates_from_reviews`) borraba todas las relaciones del PR, no solamente las de tipo `reviewer`.

Se aprovecho de cambiar el comando por un servicio, ya que cada vez que hay un cambio en la información de merge de un PR o sus reviews se actualizaban todos los tipos de relaciones que tiene el PR. Estas relaciones son independientes, por lo que las separé.

## Cambios

- Cambié el comando `CreatePullRelation` por `PullRequestRelationService`.