### PR TITLE
feat(home): change home btn text if user is already logged

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,5 @@
 class HomeController < ApplicationController
-  def index; end
+  def index
+    @user_logged_in = github_session.valid?
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,11 +3,17 @@
   <h1 class="c-presentation__title">Code review tool for GitHub pull requests </h1>
   <h3 class="c-presentation__sub-title">Hound comments on style violations in GitHub pull requests, allowing you and your team to better review and maintain a clean codebase. </h3>
   <div class="c-presentation__github-login">
-    <a class="c-github-login" href="<%= github_authenticate_path %>">
+    <a class="c-github-login" href="<%= @user_logged_in ? organizations_path : github_authenticate_path %>">
       <div class="c-github-login__logo-container">
         <img class="c-github-login__logo" src="<%= image_path('github-mark.png') %>"/>
       </div>
-      <div class="c-github-login__text">CONNECT WITH GITHUB</div>
+      <div class="c-github-login__text">
+        <% if @user_logged_in %>
+          <%= t('messages.home.go_to_dashboard').upcase %>
+        <% else %>
+          <%= t('messages.home.connect_github').upcase %>
+        <% end %>
+      </div>
     </a>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,10 @@ en:
       empty_info: Revisa tus repositorios trackeados o motiva a tu equipo a hacer más code review.
       empty_title: ¡Esta vacio!
     header:
-          close_session: Close session
+      close_session: Close session
+    home:
+      connect_github: Connect with Github
+      go_to_dashboard: Go to Dashboards
     missing:
       info: You are not registered in any github organizations or your current organizations still don't approve this applications. If you have this problem, contact with the admin of your organizations.
     settings:

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -28,6 +28,9 @@ es-CL:
       empty_title: ¡Esta vacio!
     header:
       close_session: Cerrar sesión
+    home:
+      connect_github: Conectar con Github
+      go_to_dashboard: Ver Dashboards
     missing:
       title: Estás solito en el universo
       info: No estas registrado en ninguna organización de github o las organizaciones a las cuales perteneces aún no aprueban a esta aplicación. En caso de lo ultimo, contacta al admin de tu organización.


### PR DESCRIPTION
En la vista de Home no está identificando si el usuario ya se ha logueado con Github, por lo que siempre muestra el botón "Connect to Github" que hace el login. Esto genera un problema, porque se sobreescribe el token que se tenía antes por uno nuevo con permiso de usuario normal. Por lo tanto, si antes habías pedido permisos de Admin, habría que pedirlos nuevamente.

## Cambios

- En el controlador `HomeController` se verifica si el usuario está logueado.
- Botón de home redirige directamente a los dashboards si el usuario ya ha ingresado.
- Traducción para el botón de inicio. 