### PR TITLE
fix(pr-relations): fix merge relations date to use merged_at of the pr

### DIFF
--- a/app/services/pull_request_relation_service.rb
+++ b/app/services/pull_request_relation_service.rb
@@ -6,7 +6,7 @@ class PullRequestRelationService < PowerTypes::Service.new(:pull_request)
         pull_request: @pull_request,
         github_user: @pull_request.merged_by,
         organization_id: @pull_request.repository.organization_id,
-        gh_updated_at: @pull_request,
+        gh_updated_at: @pull_request.gh_merged_at,
         target_user_id: @pull_request.owner_id
       )
     end

--- a/spec/services/pull_request_relation_service_spec.rb
+++ b/spec/services/pull_request_relation_service_spec.rb
@@ -26,6 +26,18 @@ describe PullRequestRelationService do
           end.by(1)
         )
       end
+
+      it "creates merge relations correctly" do
+        service.create_merge_relation
+        pr_relation = PullRequestRelation.by_pull_request(pull_request.id).merged_relations.first
+        expect(pr_relation).to have_attributes(
+          pull_request: pull_request,
+          github_user: pull_request.merged_by,
+          organization_id: pull_request.repository.organization_id,
+          gh_updated_at: pull_request.gh_merged_at,
+          target_user_id: pull_request.owner_id
+        )
+      end
     end
   end
 


### PR DESCRIPTION
No se esta asignado la fecha de actualización a las relaciones de tipo `merged_by` de los pull requests. Se le asignará la fecha `gh_merged_at` que es cuando se realizó el merge en Github.

## Cambios

- Asignar la fecha de merge de un pull request a la relación.
- Agregar un test para que valide que `PullRequestRelation` de tipo `merged_by` se haya creado correctamente.