### PR TITLE
Check track on create

### DIFF
--- a/app/services/github_pull_request_review_service.rb
+++ b/app/services/github_pull_request_review_service.rb
@@ -20,6 +20,7 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
   end
 
   def import_github_pull_request_review(pull_request, github_pr_review)
+    return unless pull_request.repository.reload.tracked
     params = build_pull_request_review_params(github_pr_review)
 
     if pr_review = PullRequestReview.find_by(gh_id: github_pr_review.id)

--- a/app/services/github_pull_request_review_service.rb
+++ b/app/services/github_pull_request_review_service.rb
@@ -1,12 +1,14 @@
 class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
   def import_all_from_repository(repository)
     repository.pull_requests.each do |pull_request|
+      break unless repository.tracked
       import_all_from_pull_request(pull_request)
     end
   end
 
   def import_all_from_pull_request(pull_request)
     github_pull_request_reviews(pull_request).each do |github_pull_request_review|
+      break unless pull_request.repository.tracked
       import_github_pull_request_review(pull_request, github_pull_request_review)
     end
   end

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -13,6 +13,7 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
   end
 
   def import_github_pull_request(repository, github_pull_request)
+    return unless repository.reload.tracked
     params = build_pull_request_params(github_pull_request)
 
     if pull_request = PullRequest.find_by(gh_id: github_pull_request.id)

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -1,6 +1,7 @@
 class GithubPullRequestService < PowerTypes::Service.new(:token)
   def import_all_from_repository(repository)
     github_pull_requests(repository).each do |github_pull_request|
+      break unless repository.tracked
       import_github_pull_request(repository, github_pull_request)
     end
   end

--- a/app/services/repository_tracking_service.rb
+++ b/app/services/repository_tracking_service.rb
@@ -1,15 +1,15 @@
 class RepositoryTrackingService < PowerTypes::Service.new(:repository, :token)
   def track
+    set_repository_status(true)
     clear_repository
     import_pull_requests_with_reviews
     set_repository_webhook
-    set_repository_status(true)
   end
 
   def untrack
+    set_repository_status(false)
     clear_repository
     remove_repository_webhook
-    set_repository_status(false)
   end
 
   private

--- a/app/services/repository_tracking_service.rb
+++ b/app/services/repository_tracking_service.rb
@@ -8,6 +8,7 @@ class RepositoryTrackingService < PowerTypes::Service.new(:repository, :token)
 
   def untrack
     set_repository_status(false)
+    sleep(0.5) # Wait for other process to check untracked status and stop creating pull requests
     clear_repository
     remove_repository_webhook
   end
@@ -16,7 +17,6 @@ class RepositoryTrackingService < PowerTypes::Service.new(:repository, :token)
 
   def clear_repository
     @repository.pull_requests.destroy_all
-    @repository.pull_request_reviews.destroy_all
   end
 
   def import_pull_requests_with_reviews


### PR DESCRIPTION
El proceso de *tracking* de un repositorio no para si es que este ha cambiado su estado a *no trackeado* Se agregó un validador que refresca los datos del repositorio y consulta si sigue estando *trackeado*.

## Cambios

- Agregado un validador de `repository.reload.tracked` que actualiza los datos del repositorio y verifica que siga estando *trackeado*.