### PR TITLE
Review relation on create

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -35,22 +35,21 @@ end
 #
 # Table name: pull_requests
 #
-#  id                                :integer          not null, primary key
-#  gh_id                             :integer
-#  title                             :string
-#  gh_number                         :integer
-#  pr_state                          :string
-#  html_url                          :string
-#  gh_created_at                     :datetime
-#  gh_updated_at                     :datetime
-#  gh_closed_at                      :datetime
-#  gh_merged_at                      :datetime
-#  created_at                        :datetime         not null
-#  updated_at                        :datetime         not null
-#  repository_id                     :integer
-#  owner_id                          :integer
-#  merged_by_id                      :integer
-#  last_pull_req_review_modification :datetime
+#  id            :integer          not null, primary key
+#  gh_id         :integer
+#  title         :string
+#  gh_number     :integer
+#  pr_state      :string
+#  html_url      :string
+#  gh_created_at :datetime
+#  gh_updated_at :datetime
+#  gh_closed_at  :datetime
+#  gh_merged_at  :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  repository_id :integer
+#  owner_id      :integer
+#  merged_by_id  :integer
 #
 # Indexes
 #

--- a/app/models/pull_request_review.rb
+++ b/app/models/pull_request_review.rb
@@ -1,12 +1,6 @@
 class PullRequestReview < ApplicationRecord
   belongs_to :pull_request
   belongs_to :github_user
-
-  after_save :touch_pull_request
-
-  def touch_pull_request
-    pull_request.update(last_pull_req_review_modification: Time.current)
-  end
 end
 
 # == Schema Information

--- a/app/models/pull_request_review.rb
+++ b/app/models/pull_request_review.rb
@@ -1,4 +1,6 @@
 class PullRequestReview < ApplicationRecord
+  include PowerTypes::Observable
+
   belongs_to :pull_request
   belongs_to :github_user
 end

--- a/app/observers/pull_request_observer.rb
+++ b/app/observers/pull_request_observer.rb
@@ -7,10 +7,6 @@ class PullRequestObserver < PowerTypes::Observer
       service = PullRequestRelationService.new(pull_request: object)
       service.create_merge_relation
     end
-    if object.saved_change_to_last_pull_req_review_modification?
-      service = PullRequestRelationService.new(pull_request: object)
-      service.create_review_relations
-    end
   end
 
   def destroy_pull_request_relations

--- a/app/observers/pull_request_review_observer.rb
+++ b/app/observers/pull_request_review_observer.rb
@@ -1,0 +1,8 @@
+class PullRequestReviewObserver < PowerTypes::Observer
+  after_save :update_pull_request_relations
+
+  def update_pull_request_relations
+    service = PullRequestRelationService.new(pull_request: object.pull_request)
+    service.create_review_relations
+  end
+end

--- a/app/services/pull_request_relation_service.rb
+++ b/app/services/pull_request_relation_service.rb
@@ -13,7 +13,7 @@ class PullRequestRelationService < PowerTypes::Service.new(:pull_request)
   end
 
   def create_review_relations
-    if @pull_request.pull_request_reviews.present?
+    if @pull_request.pull_request_reviews.reload.present?
       PullRequestRelation.review_relations.by_pull_request(@pull_request.id).destroy_all
       last_review_for_each_user.each do |review|
         PullRequestRelation.review_relations.create!(

--- a/db/migrate/20180424180910_remove_column_last_pr_reviews_modification.rb
+++ b/db/migrate/20180424180910_remove_column_last_pr_reviews_modification.rb
@@ -1,0 +1,5 @@
+class RemoveColumnLastPrReviewsModification < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :pull_requests, :last_pull_req_review_modification, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180421205141) do
+ActiveRecord::Schema.define(version: 20180424180910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,7 +150,6 @@ ActiveRecord::Schema.define(version: 20180421205141) do
     t.bigint "repository_id"
     t.integer "owner_id"
     t.integer "merged_by_id"
-    t.datetime "last_pull_req_review_modification"
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"
   end
 

--- a/spec/models/pull_request_review_spec.rb
+++ b/spec/models/pull_request_review_spec.rb
@@ -5,14 +5,4 @@ RSpec.describe PullRequestReview, type: :model do
     it { should belong_to(:pull_request) }
     it { should belong_to(:github_user) }
   end
-
-  describe 'on save' do
-    let!(:pull_request) { create(:pull_request) }
-    it 'touches pull request' do
-      expect do
-        create(:pull_request_review, pull_request: pull_request)
-        pull_request.reload
-      end.to(change { pull_request.last_pull_req_review_modification })
-    end
-  end
 end

--- a/spec/observers/pull_request_observer_spec.rb
+++ b/spec/observers/pull_request_observer_spec.rb
@@ -2,26 +2,14 @@ require 'rails_helper'
 
 describe PullRequestObserver, observers: true do
   describe "#update_pull_request_relations" do
-    context "when merge data is saved" do
-      let(:pull_request) { create(:pull_request) }
-      before do
-        expect_any_instance_of(PullRequestRelationService).to receive(:create_merge_relation)
-          .and_return(nil)
-      end
-
-      it "calls service to create merge relation" do
-        pull_request.update(merged_by: create(:github_user), gh_merged_at: Time.current)
-      end
+    let(:pull_request) { create(:pull_request) }
+    before do
+      expect_any_instance_of(PullRequestRelationService).to receive(:create_merge_relation)
+        .and_return(nil)
     end
 
-    context "when review data is saved" do
-      before do
-        expect_any_instance_of(PullRequestRelationService).to receive(:create_review_relations)
-          .and_return(nil)
-      end
-      it "calls CreatePullRelations" do
-        create(:pull_request_with_reviews, reviews_count: 1)
-      end
+    it "calls service to create merge relation" do
+      pull_request.update(merged_by: create(:github_user), gh_merged_at: Time.current)
     end
   end
 

--- a/spec/observers/pull_request_review_observer_spec.rb
+++ b/spec/observers/pull_request_review_observer_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe PullRequestReviewObserver, observers: true do
+  describe "#update_pull_request_relations" do
+    let(:pull_request) { create(:pull_request) }
+    let(:reviewer) { create(:github_user, login: 'reviewer') }
+
+    it "calls service to create merge relation" do
+      expect_any_instance_of(PullRequestRelationService).to receive(:create_review_relations)
+        .and_return(nil)
+      pull_request.pull_request_reviews.create(github_user: reviewer)
+    end
+  end
+end


### PR DESCRIPTION
No se estaban creando todas las relaciones correspondientes a los reviews existentes.

Una hipótesis de por qué puede pasar es que `PullRequestObserver` no se estaba llamando a la creación de relaciones cuando correspondía. Este observer crea las relaciones de review solamente si el atributo `last_pull_req_review_modification` ha cambiado y este atributo es actualizado cada vez que se  asigna un nuevo review al pull requests. Como los reviews son creados muy rápido, puede que la fecha sea la misma y se hayan creado varios reviews seguidos.

Cambiamos el gatillador a un observer de la misma clase `PullRequestReview` para que actualice las `PullRequestRelation` cada vez que se guardan.

## Cambios

* Se eliminó el atributo `last_pull_req_review_modification`.
* Se saco la actualización de las relaciones de review en `PullRequestObserver`. Ahora solo actualiza las relaciones tipo `merge_by`.
* Se agregó el observer `PullRequestReviewObserver` que llama al servicio `PullRequestRelationService` para crear las relaciones.
* Agregado llamada `reload` en `PullRequestRelationService#create_review_relations`, ya que no tenía la lista de reviews actualizada al crear las relaciones.