### PR TITLE
fix(correlation-matrix): fix alone score to use owner prs

### DIFF
--- a/app/values/correlation_matrix.rb
+++ b/app/values/correlation_matrix.rb
@@ -35,7 +35,9 @@ class CorrelationMatrix
 
   # Get user pull requests where had been merged by himself
   def gh_user_merged_pull_req_ids(gh_user)
-    @pr_relations.where(pr_relation_type: :merged_by, github_user_id: gh_user.id)
+    @pr_relations.where(target_user_id: gh_user.id,
+                        pr_relation_type: :merged_by,
+                        github_user_id: gh_user.id)
                  .group(:pull_request_id)
                  .pluck(:pull_request_id)
   end


### PR DESCRIPTION
Cuando se obtiene los puntajes de la matriz, en los puntajes de las diagonales faltaba filtrar los pull requests que el usuario era dueño `target_user_id`.