### PR TITLE
Style/buttons

### DIFF
--- a/app/assets/stylesheets/app/button.scss
+++ b/app/assets/stylesheets/app/button.scss
@@ -10,7 +10,9 @@
   font-weight: 500;
   line-height: 30px;
   border-radius: 2px;
-  padding: 2px;
+  padding: 2px 5px;
+  display: block;
+  text-decoration: none;
 
   &--light {
     background-color: $white;

--- a/app/assets/stylesheets/app/button.scss
+++ b/app/assets/stylesheets/app/button.scss
@@ -11,8 +11,15 @@
   line-height: 30px;
   border-radius: 2px;
   padding: 2px 5px;
-  display: block;
+  display: table-cell;
+  vertical-align: middle;
   text-decoration: none;
+
+  &--big {
+    height: 56px;
+    width: 304px;
+    font-size: 18px;
+  }
 
   &--light {
     background-color: $white;

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -104,11 +104,6 @@
   position: fixed;
 }
 
-.organization__setting__button {
-  width: 100%;
-  text-align: center;
-}
-
 .organization__selector {
   margin-top: 30px;
   font-family: $roboto-condensed;
@@ -254,6 +249,12 @@
     &__sync {
       margin-top: 18px;
       margin-right: 32px;
+    }
+
+    &__config {
+      position: absolute;
+      right: 32px;
+      margin-top: 18px;
     }
 
     &__body {

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -178,35 +178,6 @@
     opacity: .64;
   }
 
-  &__button {
-    height: 56px;
-    width: 304px;
-    border-radius: 2px;
-    background-color: $login-btn-bg;
-    margin: 0 auto;
-    margin-top: 40px;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    cursor: pointer;
-    text-decoration: none;
-    text-align: center;
-    border: 1px solid $white;
-
-    &-text {
-      font-size: 18px;
-      font-weight: 500;
-      line-height: 21px;
-      color: $white;
-      text-transform: uppercase;
-      text-decoration: none;
-    }
-  }
-
-  &__button-input {
-    padding-left: 35px;
-  }
-
   &-extended {
     @extend .card;
     justify-content: space-evenly;
@@ -255,6 +226,11 @@
       position: absolute;
       right: 32px;
       margin-top: 18px;
+    }
+
+    &__dashboard-button {
+      margin: 0 auto;
+      margin-top: 40px;
     }
 
     &__body {

--- a/app/views/organizations/_admin_permission.html.erb
+++ b/app/views/organizations/_admin_permission.html.erb
@@ -10,8 +10,10 @@
   <div class="card-extended__body">
     <h2 class="card__title"><%= t('messages.settings.login_with_admin_session_ask') %></h2>
     <p class="card__info"><%= t('messages.settings.login_with_admin_session_message_ask') %></p>
-    <%= link_to t('messages.settings.create_dashboard'),
-        admin_authenticate_path(gh_org: @github_organization[:login]),
-        class: "card__button card__button-text"%>
+    <div class="card-extended__dashboard-button">
+      <%= link_to t('messages.settings.create_dashboard'),
+          admin_authenticate_path(gh_org: @github_organization[:login]),
+          class: "button button--big"%>
+    </div>
   </div>
 </div>

--- a/app/views/organizations/_card_header.html.erb
+++ b/app/views/organizations/_card_header.html.erb
@@ -31,7 +31,7 @@
             <% end %>
           <% end %>
         </div>
-      </dropdown>  
+      </dropdown>
 
       <dropdown class="select">
         <div class="select__btn" slot="btn">
@@ -49,12 +49,14 @@
             <% end %>
           <% end %>
         </div>
-      </dropdown>      
-    <% end %>       
-  <% end %>      
+      </dropdown>
+    <% end %>
+  <% end %>
   <% if @is_admin && !only_organization%>
-    <a  class="card-extended__header-link" href="<%= settings_organization_path(@github_organization[:login]) %>">
-      <%= t('messages.dashboard.settings') %>
-    </a>
+    <div class="card-extended__config">
+      <a class="button" href="<%= settings_organization_path(@github_organization[:login]) %>">
+        <%= t('messages.dashboard.settings') %>
+      </a>
+    </div>
   <% end %>
 </div>

--- a/app/views/organizations/_empty.html.erb
+++ b/app/views/organizations/_empty.html.erb
@@ -6,8 +6,8 @@
       <%= t('messages.dashboard.empty_info', org:  @github_organization[:login]) %>
     </div>
     <% if @is_admin %>
-    <div class="card__button" onclick="window.location.href='<%= settings_organization_path(name: @github_organization[:login]) %>'">
-      <span class="card__button-text"><%= t('messages.dashboard.button_config') %></span>
+    <div class="card-extended__dashboard-button" onclick="window.location.href='<%= settings_organization_path(name: @github_organization[:login]) %>'">
+      <span class="button button--big"><%= t('messages.dashboard.button_config') %></span>
     </div>
     <% end %>
   </div>

--- a/app/views/organizations/_init_dashboard.html.erb
+++ b/app/views/organizations/_init_dashboard.html.erb
@@ -10,10 +10,12 @@
   <div class="card-extended__body">
     <h2 class="card__title"><%= t('messages.settings.login_with_admin_session') %></h2>
     <p class="card__info"><%= t('messages.settings.login_with_admin_session_message') %></p>
-    <%= button_to 'Inicializar Dashboard',
-        organizations_path,
-        method: :post,
-        params: { name: @github_organization[:login] },
-        class: "card__button card__button-text card__button-input" %>
+    <div class="card-extended__dashboard-button">
+      <%= button_to 'Inicializar Dashboard',
+          organizations_path,
+          method: :post,
+          params: { name: @github_organization[:login] },
+          class: "button button--big" %>
+    </div>
   </div>
 </div>

--- a/app/views/organizations/_permission.html.erb
+++ b/app/views/organizations/_permission.html.erb
@@ -5,8 +5,8 @@
     <div class="card__info">
       <%= t('messages.dashboard.permission_info', org:  @github_organization[:login]) %>
     </div>
-    <div class="card__button">
-      <span class="card__button-text"><%= t('messages.dashboard.permission_button') %></span>
+    <div class="card-extended__dashboard-button">
+      <div class="button button--big"><%= t('messages.dashboard.permission_button') %></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**Nota: esta rama salió desde chore/circleCI, por lo que debería mergearse esa primero

Se cambio la clase de estilo que se usaba para los botones que se muestran en el dashboard.

## Cambios

- Se cambio el estilo del link de Configuración para que tenga estilo consistente con los demás botones
![screen shot 2018-08-29 at 12 27 49 pm](https://user-images.githubusercontent.com/12057523/44798082-06ee1100-ab87-11e8-9086-e729f8e0ce46.png)
- Se borraron las clases `organization__setting__button`, `card-extended__button`, `card-extended__button-text` y `card-extended__button-input`. Sus definiciones se adaptaron y se movieron al archivo button.scss
- Se agregaron `__dashboard-button` y `__config` a `card-extended`. Estos funcionan como el contenedor que posiciona a los botones, al igual que `__sync`
