### PR TITLE
Feat/maintain state

### DIFF
--- a/app/controllers/concerns/github_authenticable.rb
+++ b/app/controllers/concerns/github_authenticable.rb
@@ -9,6 +9,6 @@ module GithubAuthenticable
   end
 
   def github_session
-    @github_session ||= GithubSession.new(session)
+    @github_session ||= GithubSession.new(cookies)
   end
 end

--- a/app/controllers/github_auth_controller.rb
+++ b/app/controllers/github_auth_controller.rb
@@ -1,7 +1,6 @@
 class GithubAuthController < ApplicationController
   def oauth_request
-    cookies.permanent[:access_token] = ""
-    cookies.permanent[:client_type] = ""
+    github_session.clean_session
     redirect_to root_path
   end
 
@@ -19,7 +18,7 @@ class GithubAuthController < ApplicationController
     if permitted_params[:callback_action] == 'settings'
       redirect_to settings_organization_path(name: permitted_params[:gh_org])
     else
-      redirect_to cookies["froggo_#{github_session.name}_path"] || organizations_path
+      redirect_to github_session.froggo_path || organizations_path
     end
   end
 
@@ -32,7 +31,6 @@ class GithubAuthController < ApplicationController
   def set_session_gh_access
     session_code = request.query_parameters['code']
     result = Octokit.exchange_code_for_token(session_code, ENV['GH_AUTH_ID'], ENV['GH_AUTH_SECRET'])
-    cookies.permanent[:access_token] = result[:access_token]
-    cookies.permanent[:client_type] = permitted_params[:client_type]
+    github_session.set_session(result[:access_token], permitted_params[:client_type])
   end
 end

--- a/app/controllers/github_auth_controller.rb
+++ b/app/controllers/github_auth_controller.rb
@@ -1,6 +1,7 @@
 class GithubAuthController < ApplicationController
   def oauth_request
-    session[:access_token] = nil
+    cookies.permanent[:access_token] = ""
+    cookies.permanent[:client_type] = ""
     redirect_to root_path
   end
 
@@ -15,11 +16,10 @@ class GithubAuthController < ApplicationController
 
   def callback
     set_session_gh_access
-
     if permitted_params[:callback_action] == 'settings'
       redirect_to settings_organization_path(name: permitted_params[:gh_org])
     else
-      redirect_to organizations_path
+      redirect_to cookies["froggo_#{github_session.name}_path"] || organizations_path
     end
   end
 
@@ -32,7 +32,7 @@ class GithubAuthController < ApplicationController
   def set_session_gh_access
     session_code = request.query_parameters['code']
     result = Octokit.exchange_code_for_token(session_code, ENV['GH_AUTH_ID'], ENV['GH_AUTH_SECRET'])
-    session[:access_token] = result[:access_token]
-    session[:client_type] = permitted_params[:client_type]
+    cookies.permanent[:access_token] = result[:access_token]
+    cookies.permanent[:client_type] = permitted_params[:client_type]
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,7 @@ class HomeController < ApplicationController
     @user_logged_in = github_session.valid?
 
     @org_redirect = if @user_logged_in
-                      cookies["froggo_#{github_session.name}_path"] || organizations_path
+                      github_session.froggo_path || organizations_path
                     else
                       github_authenticate_path
                     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,11 @@
 class HomeController < ApplicationController
   def index
     @user_logged_in = github_session.valid?
+
+    @org_redirect = if @user_logged_in
+                      cookies["froggo_#{github_session.name}_path"] || organizations_path
+                    else
+                      github_authenticate_path
+                    end
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -101,6 +101,6 @@ class OrganizationsController < ApplicationController
   end
 
   def save_cookie_url
-    cookies.permanent["froggo_#{github_session.name}_path"] = request.fullpath
+    github_session.save_froggo_path(request.fullpath)
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,6 @@
 class OrganizationsController < ApplicationController
   before_action :authenticate_github_user
+  before_action :save_cookie_url
   before_action :load_organization, except: [:index, :missing]
   before_action :ensure_organization_admin, only: :settings
 
@@ -97,5 +98,9 @@ class OrganizationsController < ApplicationController
     corrmat = CorrelationMatrix.new(org_id, user_ids, month_limit)
     corrmat.fill_matrix
     corrmat
+  end
+
+  def save_cookie_url
+    cookies.permanent["froggo_#{github_session.name}_path"] = request.fullpath
   end
 end

--- a/app/values/github_session.rb
+++ b/app/values/github_session.rb
@@ -1,8 +1,8 @@
 class GithubSession
   attr_accessor :session, :name, :avatar_url, :organizations
 
-  def initialize(session)
-    @session = session
+  def initialize(cookies)
+    @session = cookies
 
     if valid?
       set_user
@@ -19,15 +19,15 @@ class GithubSession
   end
 
   def valid?
-    !token.nil?
+    token && !token.empty?
   end
 
   def set_access_token(_token)
-    @session['access_token'] = _token
+    @session.permanent['access_token'] = _token
   end
 
   def set_session_type(_session_type)
-    @session['client_type'] = _session_type
+    @session.permanent['client_type'] = _session_type
   end
 
   def get_teams(organization)

--- a/app/values/github_session.rb
+++ b/app/values/github_session.rb
@@ -22,12 +22,11 @@ class GithubSession
     token && !token.empty?
   end
 
-  def set_access_token(_token)
+  def set_session(_token, _session_type)
     @session.permanent['access_token'] = _token
-  end
-
-  def set_session_type(_session_type)
     @session.permanent['client_type'] = _session_type
+    set_user
+    set_organizations
   end
 
   def get_teams(organization)
@@ -43,6 +42,19 @@ class GithubSession
         login: member.login
       }
     end
+  end
+
+  def clean_session
+    @session.permanent['access_token'] = ""
+    @session.permanent['client_type'] = ""
+  end
+
+  def froggo_path
+    @session[froggo_path_key]
+  end
+
+  def save_froggo_path(_path)
+    @session.permanent[froggo_path_key] = _path
   end
 
   private
@@ -63,6 +75,10 @@ class GithubSession
         avatar_url: mem.organization.avatar_url
       }
     end
+  end
+
+  def froggo_path_key
+    "froggo_#{@name}_path"
   end
 
   def client

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,7 @@
     <h1 class="c-presentation__title">Code review tool for GitHub pull requests </h1>
     <h3 class="c-presentation__sub-title">Hound comments on style violations in GitHub pull requests, allowing you and your team to better review and maintain a clean codebase. </h3>
     <div class="c-presentation__github-login">
-      <a class="c-github-login" href="<%= @user_logged_in ? organizations_path : github_authenticate_path %>">
+      <a class="c-github-login" href="<%= @org_redirect %>">
         <span class="c-github-login__logo-container">
           <img class="c-github-login__logo" src="<%= image_path('github-mark.png') %>"/>
         </span>

--- a/spec/controllers/concerns/github_authenticable_spec.rb
+++ b/spec/controllers/concerns/github_authenticable_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe GithubAuthenticable do
     class DummyController
       include GithubAuthenticable
 
-      def session
-        "session"
+      def cookies
+        "cookies"
       end
 
       def redirect_to(path)
@@ -30,7 +30,7 @@ RSpec.describe GithubAuthenticable do
 
   describe "#authenticate_github_user" do
     before do
-      expect(GithubSession).to receive(:new).with(subject.session).and_return(github_session)
+      expect(GithubSession).to receive(:new).with(subject.cookies).and_return(github_session)
     end
 
     context "with valid github session" do
@@ -58,7 +58,7 @@ RSpec.describe GithubAuthenticable do
     let(:github_session) { double }
 
     before do
-      expect(GithubSession).to receive(:new).with(subject.session).and_return(github_session)
+      expect(GithubSession).to receive(:new).with(subject.cookies).and_return(github_session)
     end
 
     it { expect(subject.github_session).to eq(github_session) }

--- a/spec/controllers/github_auth_controller_spec.rb
+++ b/spec/controllers/github_auth_controller_spec.rb
@@ -3,32 +3,57 @@ require 'rails_helper'
 RSpec.describe GithubAuthController, type: :controller do
   describe 'GET #callback' do
     let(:github_return_code) { 'github_code' }
-    subject { get :callback, params: { client_type: :member, code: github_return_code } }
     let(:token_result) { { access_token: 'token' } }
+    let!(:github_session) { double(name: 'name') }
+
     before do
       expect(Octokit).to receive(:exchange_code_for_token)
         .with(github_return_code, ENV['GH_AUTH_ID'], ENV['GH_AUTH_SECRET'])
         .and_return(token_result)
+      allow(subject).to receive(:github_session)
+        .and_return(github_session)
     end
 
-    it 'sets session values correctly' do
-      subject
-      expect(session[:access_token]).to eq(token_result[:access_token])
-      expect(session[:client_type]).to eq('member')
+    context 'from home' do
+      before do
+        get :callback, params: { client_type: :member, code: github_return_code }
+      end
+
+      it 'sets session values correctly' do
+        expect(cookies["access_token"]).to eq(token_result[:access_token])
+        expect(cookies["client_type"]).to eq('member')
+      end
     end
 
-    it { expect(subject).to redirect_to(organizations_path) }
+    context 'from home without last path in cookies' do
+      before do
+        get :callback, params: { client_type: :member, code: github_return_code }
+      end
+
+      it { expect(response).to redirect_to(organizations_path) }
+    end
+
+    context 'from home with last path in cookies' do
+      before do
+        cookies["froggo_#{github_session.name}_path"] = organization_path(name: 'org')
+        get :callback, params: { client_type: :member, code: github_return_code }
+      end
+
+      it {
+        expect(response).to redirect_to(cookies["froggo_#{github_session.name}_path"])
+      }
+    end
 
     context 'from dashboard settings of organization' do
       let(:gh_org) { 'test_org' }
-      subject do
+      before do
         get :callback, params: { client_type: :member,
                                  code: github_return_code,
                                  callback_action: 'settings',
                                  gh_org: gh_org }
       end
 
-      it { expect(subject).to redirect_to(settings_organization_path(name: gh_org)) }
+      it { expect(response).to redirect_to(settings_organization_path(name: gh_org)) }
     end
   end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 RSpec.describe HomeController, type: :controller do
   describe "GET #index" do
     let(:valid) { true }
-    let!(:github_session) { double(name: 'login', token: 'token', valid?: valid) }
+    let!(:github_session) do
+      double(name: 'login', token: 'token', valid?: valid, froggo_path: 'path')
+    end
     before do
       allow(subject).to receive(:github_session).and_return(github_session)
       get :index

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,9 +2,27 @@ require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do
   describe "GET #index" do
-    it "returns http success" do
+    let(:valid) { true }
+    let!(:github_session) { double(name: 'login', token: 'token', valid?: valid) }
+    before do
+      allow(subject).to receive(:github_session).and_return(github_session)
       get :index
-      expect(response).to have_http_status(:success)
+    end
+
+    context "when user is not authenticated" do
+      let(:valid) { false }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context "when user is authenticated" do
+      let(:valid) { true }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 end

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe OrganizationsController, type: :controller do
 
   describe "GET #index" do
     context "when user does not belongs to any organizations" do
-      let(:github_session) { double(organizations: [], name: 'name') }
+      let(:github_session) { double(organizations: [], name: 'name', save_froggo_path: 'path') }
 
       before do
         get :index
@@ -25,7 +25,9 @@ RSpec.describe OrganizationsController, type: :controller do
     end
 
     context "when user belongs to at least one organization, but no organization is selected" do
-      let(:github_session) { double(organizations: github_organizations, name: 'name') }
+      let(:github_session) do
+        double(organizations: github_organizations, name: 'name', save_froggo_path: 'path')
+      end
 
       before do
         get :index
@@ -38,7 +40,9 @@ RSpec.describe OrganizationsController, type: :controller do
   end
 
   describe "#show" do
-    let(:github_session) { double(organizations: github_organizations, name: 'name') }
+    let(:github_session) do
+      double(organizations: github_organizations, name: 'name', save_froggo_path: 'path')
+    end
 
     context "when user belongs to the selected organization" do
       before do
@@ -87,7 +91,8 @@ RSpec.describe OrganizationsController, type: :controller do
       double(
         session: { client_type: "admin" },
         organizations: [login: "platanus", role: role],
-        name: 'name'
+        name: 'name',
+        save_froggo_path: 'path'
       )
     end
 

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe OrganizationsController, type: :controller do
   end
 
   describe "GET #index" do
-    context "when ser does not belongs to any organizations" do
-      let(:github_session) { double(organizations: []) }
+    context "when user does not belongs to any organizations" do
+      let(:github_session) { double(organizations: [], name: 'name') }
 
       before do
         get :index
@@ -25,7 +25,7 @@ RSpec.describe OrganizationsController, type: :controller do
     end
 
     context "when user belongs to at least one organization, but no organization is selected" do
-      let(:github_session) { double(organizations: github_organizations) }
+      let(:github_session) { double(organizations: github_organizations, name: 'name') }
 
       before do
         get :index
@@ -38,9 +38,9 @@ RSpec.describe OrganizationsController, type: :controller do
   end
 
   describe "#show" do
-    let(:github_session) { double(organizations: github_organizations) }
+    let(:github_session) { double(organizations: github_organizations, name: 'name') }
 
-    context "when user belongs the selected organization" do
+    context "when user belongs to the selected organization" do
       before do
         get :show, params: { name: "platanus" }
       end
@@ -86,7 +86,8 @@ RSpec.describe OrganizationsController, type: :controller do
     let(:github_session) do
       double(
         session: { client_type: "admin" },
-        organizations: [login: "platanus", role: role]
+        organizations: [login: "platanus", role: role],
+        name: 'name'
       )
     end
 
@@ -100,7 +101,7 @@ RSpec.describe OrganizationsController, type: :controller do
       it { expect(response).to have_http_status(200) }
     end
 
-    context "when user is admin" do
+    context "when user is member" do
       let(:role) { "member" }
 
       it { expect(response).to redirect_to('/organizations/platanus') }

--- a/spec/values/github_session_spec.rb
+++ b/spec/values/github_session_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe GithubSession, type: :class do
   let(:user_response) { JSON.parse({ 'login': 'user login', 'avatar_url': 'avatar' }.to_json) }
 
   let!(:client) { double(user: user_response, organization_memberships: org_response) }
+  subject { GithubSession.new(cookies) }
 
   def create_org_response(id, org, avatar_url, role)
     double(
@@ -31,17 +32,53 @@ RSpec.describe GithubSession, type: :class do
   end
 
   context 'when initialized with correct session' do
-    subject { GithubSession.new(cookies) }
-    it 'has the correct session info' do
+    it 'has the correct info' do
       expect(subject.session['access_token']).to eq(cookies['access_token'])
       expect(subject.session['client_type']).to eq(cookies['client_type'])
-    end
-
-    it 'changes the session info when session changes' do
-      expect(subject.set_access_token('another token')).to eq(cookies['access_token'])
-      expect(subject.set_session_type('admin')).to eq(cookies['client_type'])
+      expect(subject.name).to eq(client.user["login"])
+      expect(subject.avatar_url).to eq(client.user["avatar_url"])
+      expect(subject.organizations).to eq(
+        [
+          {
+            id: org_response[0].organization.id,
+            login: org_response[0].organization.login,
+            role: org_response[0].role,
+            avatar_url: org_response[0].organization.avatar_url
+          },
+          {
+            id: org_response[1].organization.id,
+            login: org_response[1].organization.login,
+            role: org_response[1].role,
+            avatar_url: org_response[1].organization.avatar_url
+          }
+        ]
+      )
     end
 
     it { expect(subject.valid?).to eq(true) }
+  end
+
+  context 'when session info is set' do
+    before do
+      subject.set_session('another token', 'admin')
+    end
+
+    it 'has the correct session info' do
+      expect(subject.session['access_token']).to eq(cookies['access_token'])
+      expect(subject.session['client_type']).to eq(cookies['client_type'])
+      expect(subject.session['access_token']).to eq('another token')
+      expect(subject.session['client_type']).to eq('admin')
+    end
+  end
+
+  context 'when cleaning session' do
+    before do
+      subject.clean_session
+    end
+
+    it 'erases cookies' do
+      expect(cookies['access_token']).to eq("")
+      expect(cookies['client_type']).to eq("")
+    end
   end
 end

--- a/spec/values/github_session_spec.rb
+++ b/spec/values/github_session_spec.rb
@@ -1,11 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe GithubSession, type: :class do
-  let!(:session) do
-    JSON.parse({
-      'access_token': 'a token',
-      'client_type': 'member'
-    }.to_json)
+  let(:cookies) do
+    ActionDispatch::Cookies::CookieJar.build({}, 'access_token': 'a token', 'client_type': 'member')
   end
 
   let(:org_response) do
@@ -34,15 +31,15 @@ RSpec.describe GithubSession, type: :class do
   end
 
   context 'when initialized with correct session' do
-    subject { GithubSession.new(session) }
+    subject { GithubSession.new(cookies) }
     it 'has the correct session info' do
-      expect(subject.session['access_token']).to eq(session['access_token'])
-      expect(subject.session['client_type']).to eq(session['client_type'])
+      expect(subject.session['access_token']).to eq(cookies['access_token'])
+      expect(subject.session['client_type']).to eq(cookies['client_type'])
     end
 
     it 'changes the session info when session changes' do
-      expect(subject.set_access_token('another token')).to eq(session['access_token'])
-      expect(subject.set_session_type('admin')).to eq(session['client_type'])
+      expect(subject.set_access_token('another token')).to eq(cookies['access_token'])
+      expect(subject.set_session_type('admin')).to eq(cookies['client_type'])
     end
 
     it { expect(subject.valid?).to eq(true) }


### PR DESCRIPTION
Al apretar el botón "Ver Dashboard"/"Conectar con Github" del _home, ahora se redirige al último path visitado dentro del dashboard.

## Cambios
- Ahora se persiste la sesión y la conexión con github aún luego de cerrado el browser. Para esto, se reemplazó el uso de `session` por `cookies` permanentes para cada usuario
- Se agregó un `before_action` a el `OrganizationsController` para guardar el path actual en cada navegación
- Se saca el redirect del callback del botón del home desde las cookies, si es que existe y si el usuario está loggeado
- Si el usuario no está loggeado, se manda a la autenticación con Github y se saca el redirect del callback desde las cookies, si es que existe

### Tests
- Lo que usaba session, se cambio por cookies. En `github_session_spec.rb` esto implico crear el objeto cookies, ya que este no es un controller y no tiene acceso directo a ellas.
- En `home_controller.rb` se agregó test en caso de que esté o no loggeado el usuario
- En `github_auth_controller_spec.rb` se agregó los tests correspondientes a la nueva funcionalidad
