### PR TITLE
Feat/sticky side users

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -5,9 +5,9 @@ const offsetTop = 164;
 $(document).ready(() => {
   $(document).scroll(() => {
     if (document.documentElement.scrollTop > offsetTop) {
-      $('#sticky-head').css({ top: (document.documentElement.scrollTop) - offsetTop, position: 'relative' });
+      $('#sticky-head, #sticky-corner').css({ top: (document.documentElement.scrollTop) - offsetTop, position: 'relative' });
     } else {
-      $('#sticky-head').css({ top: 0, position: 'inherit' });
+      $('#sticky-head, #sticky-corner').css({ top: 0, position: 'inherit' });
     }
   });
 });

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -20,7 +20,7 @@
   border-spacing: 0;
   display: flex;
   margin: 0 auto;
-  width: 100%;
+  max-width: 100%;
 }
 
 .matrix__head {

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -16,10 +16,11 @@
 }
 
 .matrix-dashboard {
-  width: fit-content;
-  margin: 0 auto;
-  border-spacing: 0;
   border-collapse: collapse;
+  border-spacing: 0;
+  display: flex;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .matrix__head {
@@ -33,6 +34,10 @@
 
 .matrix__row {
   display: flex;
+}
+
+.matrix__values {
+  overflow: auto;
 }
 
 .matrix__user {
@@ -61,17 +66,18 @@
 }
 
 .matrix__pullrequest {
-  width: 66px;
-  border: .5px solid $primary-border;
   background-color: $white;
-  padding: 0;
+  border: .5px solid $primary-border;
+  display: flex;
+  flex: 0 0 66px;
+  flex-direction: column;
+  height: 69px;
+  justify-content: center;
   margin: -1px 0 0 -1px;
+  padding: 0;
   text-align: center;
   vertical-align: middle;
-  flex: 0 0 66px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+  width: 66px;
 }
 
 .matrix__pullrequest-border {
@@ -137,7 +143,6 @@
       height: auto;
       background-color: $matrix-bg;
       margin-bottom: 0;
-      overflow: auto;
     }
   }
 }

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -29,7 +29,6 @@
   position: sticky;
   top: 0;
   height: 67px;
-  align-items: flex-end;
 }
 
 .matrix__row {
@@ -48,9 +47,9 @@
 
   &--head {
     @extend .matrix__user;
-    height: 55px;
     flex: 0 0 65px;
     padding: 0;
+    padding-top: 12px;
   }
 }
 

--- a/app/views/organizations/_dashboard_table.html.erb
+++ b/app/views/organizations/_dashboard_table.html.erb
@@ -5,26 +5,30 @@
       <%= t('messages.dashboard.empty_team', team:  @team[:name]) %>
     <% else %>
       <div class="matrix-dashboard">
-        <div class="matrix__head" id="sticky-head">
-          <div class="matrix__user--head"></div>
-          <% @corrmat.selected_users.each do |user| %>
-            <div class="matrix__user--head">
+        <div>
+          <div class="matrix__user--head" id="sticky-corner"></div>
+          <% @corrmat.selected_users.each_with_index do |b, i| %>
+            <div class="matrix__user">
+              <a href="<%= b.html_url %>" title="<%= b.login %>">
+                <img class="matrix__user-img" src="<%= b.avatar_url %>">
+              </a>
+            </div>
+          <% end %>
+        </div>
+        <div class="matrix__values">
+          <div class="matrix__head" id="sticky-head">
+            <% @corrmat.selected_users.each do |user| %>
+              <div class="matrix__user--head">
               <div class="matrix__picture">
                 <a href="<%= user.html_url %>" title="<%= user.login %>">
                   <img class="matrix__user-img" src="<%= user.avatar_url %>">
                 </a>
               </div>
-            </div>
-          <% end %>
-        </div>
-        <div>
+              </div>
+            <% end %>
+          </div>
           <% @corrmat.selected_users.each_with_index do |b, i| %>
             <div class="matrix__row">
-              <div class="matrix__user stick_vertical">
-                <a href="<%= b.html_url %>" title="<%= b.login %>">
-                  <img class="matrix__user-img" src="<%= b.avatar_url %>">
-                </a>
-              </div>
               <% @corrmat.selected_users.each_with_index do |a, j| %>
                 <div class="matrix__pullrequest">
                   <span class="matrix__pullrequest__number<%= if i == j then


### PR DESCRIPTION
Al hacer scroll horizontal en la matriz, ahora los usuarios se mantienen, facilitando la visualización de información

**Antes:**
![image](https://user-images.githubusercontent.com/12057523/48287901-3358c000-e449-11e8-9bba-6b1b455cee3f.png)

**Ahora:**
![image](https://user-images.githubusercontent.com/12057523/48287876-19b77880-e449-11e8-9665-50daa6d43b97.png)

### Cambios
- Antes se usaba una estructura de filas para definir la matriz, incluyendo la columna y fila con los usuarios. Ahora, se cambio a una estructura con dos columnas:
    1. Columna de usuarios
    2. "Columna" con todas las filas de la matriz, incluída la primera con los usuarios
De esta manera, se muestran lado a lado con flex y se hace que el scroll se haga solo para la columna 2 con los valores, manteniendo fijos a los usuarios
- Antes se usaba `align-items: flex-end;` en `matrix__head`. Esto provocaba que hubiera un espacio vacío en la parte superior del head, ya que su hijo tenía un height menor. Esto se cambio para que el hijo mantenga el height y se le agrega un `padding-top`
- El `div` vacío que correspondía a la esquina superior izquierda se pasó a la primera columna. Debido a que ya no estaba dentro del elemento de `id = sticky-head`, se le da su propio id y se agrega a la función de JS