### PR TITLE
Feat/public dashboard

### DIFF
--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -5,6 +5,9 @@ const autoscrollInterval = 10000;
 
 $(document).ready(() => {
   $(document).scroll(() => {
+    if ($('.card-extended--fullscreen')[0]) {
+      return;
+    }
     if (document.documentElement.scrollTop > offsetTop) {
       $('#sticky-head, #sticky-corner').css({ top: (document.documentElement.scrollTop) - offsetTop, position: 'relative' });
     } else {
@@ -15,19 +18,19 @@ $(document).ready(() => {
 
 $(document).ready(() => {
   let upToDown = true;
-  setInterval(() => {
-    const fullscreenDashboard = $('.card-extended--fullscreen')[0];
-    if (fullscreenDashboard.scrollTop >= fullscreenDashboard.scrollHeight - fullscreenDashboard.offsetHeight) {
-      upToDown = false;
-    } else if (fullscreenDashboard.scrollTop === 0) {
-      upToDown = true;
-    }
-    if (window.location.href.includes('public')) {
-      if (upToDown) {
-        fullscreenDashboard.scrollBy(0, fullscreenDashboard.offsetHeight);
-      } else {
-        fullscreenDashboard.scrollBy(0, -fullscreenDashboard.offsetHeight);
+  if (window.location.href.includes('public')) {
+    setInterval(() => {
+      const viewport = document.documentElement;
+      if (viewport.scrollTop >= viewport.scrollHeight - viewport.clientHeight) {
+        upToDown = false;
+      } else if (viewport.scrollTop === 0) {
+        upToDown = true;
       }
-    }
-  }, autoscrollInterval);
+      if (upToDown) {
+        viewport.scrollBy(0, viewport.clientHeight);
+      } else {
+        viewport.scrollBy(0, -viewport.clientHeight);
+      }
+    }, autoscrollInterval);
+  }
 });

--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -1,6 +1,7 @@
 /* global document, $ */
 
 const offsetTop = 164;
+const autoscrollInterval = 10000;
 
 $(document).ready(() => {
   $(document).scroll(() => {
@@ -10,4 +11,23 @@ $(document).ready(() => {
       $('#sticky-head, #sticky-corner').css({ top: 0, position: 'inherit' });
     }
   });
+});
+
+$(document).ready(() => {
+  let upToDown = true;
+  setInterval(() => {
+    const fullscreenDashboard = $('.card-extended--fullscreen')[0];
+    if (fullscreenDashboard.scrollTop >= fullscreenDashboard.scrollHeight - fullscreenDashboard.offsetHeight) {
+      upToDown = false;
+    } else if (fullscreenDashboard.scrollTop === 0) {
+      upToDown = true;
+    }
+    if (window.location.href.includes('public')) {
+      if (upToDown) {
+        fullscreenDashboard.scrollBy(0, fullscreenDashboard.offsetHeight);
+      } else {
+        fullscreenDashboard.scrollBy(0, -fullscreenDashboard.offsetHeight);
+      }
+    }
+  }, autoscrollInterval);
 });

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -190,14 +190,13 @@
     color: $primary;
 
     &--fullscreen {
-      height: 100vh;
-      width: 100vw;
       margin: 0;
-      overflow: auto;
-    }
+      min-height: 100vh;
+      width: 100%;
 
-    &--fullscreen .matrix__values {
-      overflow: visible;
+      .matrix__values {
+        overflow: visible;
+      }
     }
 
     &__last-update {

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -50,6 +50,8 @@
     flex: 0 0 65px;
     padding: 0;
     padding-top: 12px;
+    position: sticky;
+    top: 0;
   }
 }
 
@@ -187,6 +189,17 @@
     justify-content: space-evenly;
     color: $primary;
 
+    &--fullscreen {
+      height: 100vh;
+      width: 100vw;
+      margin: 0;
+      overflow: auto;
+    }
+
+    &--fullscreen .matrix__values {
+      overflow: visible;
+    }
+
     &__last-update {
       font-size: 11px;
       color: $secondary-color;
@@ -248,6 +261,10 @@
         @extend .card-extended__body;
         justify-content: flex-start;
       }
+    }
+
+    &--fullscreen &__body {
+      margin: 0;
     }
 
     &__repo-name {

--- a/app/views/organizations/_dashboard_table.html.erb
+++ b/app/views/organizations/_dashboard_table.html.erb
@@ -1,8 +1,8 @@
-<div class="card-extended">
+<div class="<%= "card-extended #{'card-extended--fullscreen' if @public_mode}" %>">
   <% if !@public_mode %>
     <%= render "card_header", only_organization: false %>
   <% end %>
-  <div class="card-extended__body ">
+  <div class="card-extended__body">
     <% if @corrmat.selected_users.empty? %>
       <%= t('messages.dashboard.empty_team', team:  @team[:name]) %>
     <% else %>
@@ -20,12 +20,12 @@
         <div class="matrix__values">
           <div class="matrix__head" id="sticky-head">
             <% @corrmat.selected_users.each do |user| %>
-              <div class="matrix__user--head">
-              <div class="matrix__picture">
-                <a href="<%= user.html_url %>" title="<%= user.login %>">
-                  <img class="matrix__user-img" src="<%= user.avatar_url %>">
-                </a>
-              </div>
+              <div class="matrix__user">
+                <div class="matrix__picture">
+                  <a href="<%= user.html_url %>" title="<%= user.login %>">
+                    <img class="matrix__user-img" src="<%= user.avatar_url %>">
+                  </a>
+                </div>
               </div>
             <% end %>
           </div>

--- a/app/views/organizations/_dashboard_table.html.erb
+++ b/app/views/organizations/_dashboard_table.html.erb
@@ -20,7 +20,7 @@
         <div class="matrix__values">
           <div class="matrix__head" id="sticky-head">
             <% @corrmat.selected_users.each do |user| %>
-              <div class="matrix__user">
+              <div class="matrix__user--head">
                 <div class="matrix__picture">
                   <a href="<%= user.html_url %>" title="<%= user.login %>">
                     <img class="matrix__user-img" src="<%= user.avatar_url %>">

--- a/app/views/organizations/_dashboard_table.html.erb
+++ b/app/views/organizations/_dashboard_table.html.erb
@@ -1,5 +1,7 @@
 <div class="card-extended">
-  <%= render "card_header", only_organization: false %>
+  <% if !@public_mode %>
+    <%= render "card_header", only_organization: false %>
+  <% end %>
   <div class="card-extended__body ">
     <% if @corrmat.selected_users.empty? %>
       <%= t('messages.dashboard.empty_team', team:  @team[:name]) %>

--- a/app/views/organizations/public.html.erb
+++ b/app/views/organizations/public.html.erb
@@ -1,0 +1,3 @@
+<% if @has_dashboard && !((@corrmat.nil? || @corrmat.selected_users.empty?) && !@team) %>
+  <%= render "dashboard_table" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   resources :organizations, param: :name do
     get 'missing' => 'organizations#missing', on: :collection
     get 'settings' => 'organizations#settings', on: :member
+    get 'public' => 'organizations#public', on: :member
   end
 
   scope path: '/api', defaults: { format: 'json' } do


### PR DESCRIPTION
Se habilitó una ruta para poder ver públicamente el dashboard de una empresa

![nov-23-2018 10-43-34](https://user-images.githubusercontent.com/12057523/48946526-c9421f80-ef0c-11e8-9969-5cb2791906c8.gif)

**En un display:**
![20181123_091334](https://user-images.githubusercontent.com/12057523/48946568-e8d94800-ef0c-11e8-8117-e22c57669721.jpg)


### Cambios
- Se definio la ruta `:organization/public` donde se muestra un dashboard en pantalla completa en el que no se muestra el header de la matriz
- Se agregó JS para que la matriz haga un scroll cada diez segundos, bajando o subiendo según corresponda el alto de la pantalla