### PR TITLE
Fix test for Correlation Matrix

### DIFF
--- a/spec/values/correlation_matrix_spec.rb
+++ b/spec/values/correlation_matrix_spec.rb
@@ -3,9 +3,17 @@ require 'rails_helper'
 RSpec.describe CorrelationMatrix, type: :class do
   let!(:organization) { create(:organization) }
   let!(:repository) { create(:repository, organization: organization) }
+  let!(:owner) { create(:github_user, gh_id: 3, login: 'gh_owner') }
+  let!(:reviewer) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
+  let!(:current_user) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
+  let!(:reviewer_membership) do
+    create(:organization_membership, organization: organization, github_user: reviewer)
+  end
+  let!(:owner_membership) do
+    create(:organization_membership, organization: organization, github_user: owner)
+  end
 
   context 'when initialized with empty organization' do
-    let!(:current_user) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
     subject { CorrelationMatrix.new(organization.id, nil, current_user.login) }
     it 'has empty data' do
       expect(subject.data).to be_empty
@@ -13,18 +21,9 @@ RSpec.describe CorrelationMatrix, type: :class do
   end
 
   context 'when initialized' do
-    let!(:owner) { create(:github_user, gh_id: 3, login: 'gh_owner') }
     let!(:pull_requests) { [create(:pull_request, repository: repository, owner: owner)] }
-    let!(:reviewer) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
-    let!(:current_user) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
     let!(:pr_relation) do
       create(:pull_request_relation, pull_request: pull_requests[0], github_user: reviewer)
-    end
-    let!(:reviewer_membership) do
-      create(:organization_membership, organization: organization, github_user: reviewer)
-    end
-    let!(:owner_membership) do
-      create(:organization_membership, organization: organization, github_user: owner)
     end
 
     subject do
@@ -42,16 +41,7 @@ RSpec.describe CorrelationMatrix, type: :class do
   end
 
   context 'when fill_matrix' do
-    let!(:owner) { create(:github_user, gh_id: 3, login: 'gh_owner') }
-    let!(:reviewer) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
     let!(:pull_requests) { [create(:pull_request, repository: repository, owner: owner)] }
-    let!(:current_user) { create(:github_user, gh_id: 8, login: 'gh_owner') }
-    let!(:owner_membership) do
-      create(:organization_membership, organization: organization, github_user: owner)
-    end
-    let!(:reviewer_membership) do
-      create(:organization_membership, organization: organization, github_user: reviewer)
-    end
     before do
       create(:pull_request_relation, pull_request: pull_requests[0], github_user: owner)
       create(:pull_request_relation, pull_request: pull_requests[0], github_user: reviewer)
@@ -84,20 +74,11 @@ RSpec.describe CorrelationMatrix, type: :class do
   end
 
   context 'filter by user_ids' do
-    let!(:owner) { create(:github_user, gh_id: 3, login: 'gh_owner') }
-    let!(:reviewer) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
+    let!(:pull_requests) { [create(:pull_request, repository: repository, owner: owner)] }
     let!(:other) { create(:github_user, gh_id: 9, login: 'gh_other') }
-    let!(:owner_membership) do
-      create(:organization_membership, organization: organization, github_user: owner)
-    end
-    let!(:reviewer_membership) do
-      create(:organization_membership, organization: organization, github_user: reviewer)
-    end
     let!(:other_membership) do
       create(:organization_membership, organization: organization, github_user: other)
     end
-    let!(:pull_requests) { [create(:pull_request, repository: repository, owner: owner)] }
-    let!(:current_user) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
     before do
       create(:pull_request_relation, pull_request: pull_requests[0], github_user_id: owner.id)
       create(:pull_request_relation, pull_request: pull_requests[0], github_user_id: reviewer.id)

--- a/spec/values/correlation_matrix_spec.rb
+++ b/spec/values/correlation_matrix_spec.rb
@@ -20,10 +20,24 @@ RSpec.describe CorrelationMatrix, type: :class do
     let!(:pr_relation) do
       create(:pull_request_relation, pull_request: pull_requests[0], github_user: reviewer)
     end
+    let!(:reviewer_membership) do
+      create(:organization_membership, organization: organization, github_user: reviewer)
+    end
+    let!(:owner_membership) do
+      create(:organization_membership, organization: organization, github_user: owner)
+    end
 
-    subject { CorrelationMatrix.new(organization.id, nil, current_user.login) }
+    subject do
+      CorrelationMatrix.new(organization.id, [owner.gh_id, reviewer.gh_id], current_user.login)
+    end
+
     it 'has zeros value' do
       expect(subject.data[[0, 0]]).to eq(0)
+    end
+
+    it 'should place current user first' do
+      subject.fill_matrix
+      expect(subject.selected_users.first.login).to eq('gh_owner')
     end
   end
 
@@ -32,6 +46,12 @@ RSpec.describe CorrelationMatrix, type: :class do
     let!(:reviewer) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
     let!(:pull_requests) { [create(:pull_request, repository: repository, owner: owner)] }
     let!(:current_user) { create(:github_user, gh_id: 8, login: 'gh_owner') }
+    let!(:owner_membership) do
+      create(:organization_membership, organization: organization, github_user: owner)
+    end
+    let!(:reviewer_membership) do
+      create(:organization_membership, organization: organization, github_user: reviewer)
+    end
     before do
       create(:pull_request_relation, pull_request: pull_requests[0], github_user: owner)
       create(:pull_request_relation, pull_request: pull_requests[0], github_user: reviewer)
@@ -42,12 +62,12 @@ RSpec.describe CorrelationMatrix, type: :class do
     it 'should change data value if exist' do
       expect do
         subject.fill_matrix
-      end.to change { subject.data.length }.by(0)
+      end.to change { subject.data.length }.by(3)
     end
 
     it 'should assign cooperate scope correctly' do
       subject.fill_matrix
-      expect(subject.data[[subject.pos_hash[owner.id], subject.pos_hash[reviewer.id]]]).to be(0)
+      expect(subject.data[[subject.pos_hash[owner.id], subject.pos_hash[reviewer.id]]]).to be(1)
       expect(subject.data[[0, 0]]).to be(0)
       expect(subject.data[[1, 1]]).to be(0)
     end
@@ -59,7 +79,7 @@ RSpec.describe CorrelationMatrix, type: :class do
       create(:pull_request_relation, pull_request: new_pr, github_user: owner,
                                      pr_relation_type: :reviewer)
       subject.fill_matrix
-      expect(subject.data[[subject.pos_hash[owner.id], subject.pos_hash[owner.id]]]).to be(0)
+      expect(subject.data[[subject.pos_hash[owner.id], subject.pos_hash[owner.id]]]).to be(1)
     end
   end
 
@@ -92,37 +112,6 @@ RSpec.describe CorrelationMatrix, type: :class do
       subject.fill_matrix
       expect(organization.members.length).to eq(3)
       expect(subject.selected_users.length).to eq(2)
-    end
-  end
-
-  context 'order selected users' do
-    let!(:owner) { create(:github_user, gh_id: 3, login: 'gh_owner') }
-    let!(:reviewer) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
-    let!(:other) { create(:github_user, gh_id: 9, login: 'gh_other') }
-    let!(:reviewer_membership) do
-      create(:organization_membership, organization: organization, github_user: reviewer)
-    end
-    let!(:owner_membership) do
-      create(:organization_membership, organization: organization, github_user: owner)
-    end
-    let!(:other_membership) do
-      create(:organization_membership, organization: organization, github_user: other)
-    end
-    let!(:pull_requests) { [create(:pull_request, repository: repository, owner: owner)] }
-    let!(:current_user) { create(:github_user, gh_id: 8, login: 'gh_owner') }
-    before do
-      create(:pull_request_relation, pull_request: pull_requests[0], github_user_id: owner.id)
-      create(:pull_request_relation, pull_request: pull_requests[0], github_user_id: reviewer.id)
-      create(:pull_request_relation, pull_request: pull_requests[0], github_user_id: other.id)
-    end
-
-    subject do
-      CorrelationMatrix.new(organization.id, [owner.gh_id, reviewer.gh_id], current_user.login)
-    end
-
-    it 'should place current user first' do
-      subject.fill_matrix
-      expect(subject.selected_users.first.login).to eq('gh_owner')
     end
   end
 end


### PR DESCRIPTION
En el archivo: _spec/values/correlation_matrix_spec.rben_, el test `'should assign alone score correctly'` no estaba probando lo que realmente debía. Faltaba añadir los usuarios a la organización correspondiente para que la matriz los tome en cuenta y los agregue.

Además se hizo un refactor del test `'should place current user first'`, estaba en un contexto separado siendo que el contexto debiera ser el mismo usado al probar cuando se inicializa la matriz.