### PR TITLE
Fix/safari incompatibilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'active_model_serializers', '~> 0.10'
 gem 'active_skin'
 gem 'activeadmin', '~> 1.1.0'
 gem 'activeadmin_addons', '~> 1.1.2'
+gem "autoprefixer-rails"
 gem 'aws-sdk', '~> 2.5'
 gem 'coffee-rails', '~> 4.2'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     arbre (1.1.1)
       activesupport (>= 3.0.0)
     arel (8.0.0)
+    autoprefixer-rails (8.4.1)
+      execjs
     aws-sdk (2.10.98)
       aws-sdk-resources (= 2.10.98)
     aws-sdk-core (2.10.98)
@@ -439,6 +441,7 @@ DEPENDENCIES
   activeadmin (~> 1.1.0)
   activeadmin_addons (~> 1.1.2)
   annotate
+  autoprefixer-rails
   aws-sdk (~> 2.5)
   better_errors
   binding_of_caller
@@ -492,4 +495,4 @@ DEPENDENCIES
   webpacker!
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -21,15 +21,15 @@ $(document).ready(() => {
   if (window.location.href.includes('public')) {
     setInterval(() => {
       const viewport = document.documentElement;
-      if (viewport.scrollTop >= viewport.scrollHeight - viewport.clientHeight) {
+      if ($(document).scrollTop() >= viewport.scrollHeight - viewport.clientHeight) {
         upToDown = false;
-      } else if (viewport.scrollTop === 0) {
+      } else if ($(document).scrollTop() === 0) {
         upToDown = true;
       }
       if (upToDown) {
-        viewport.scrollBy(0, viewport.clientHeight);
+        window.scrollBy(0, viewport.clientHeight);
       } else {
-        viewport.scrollBy(0, -viewport.clientHeight);
+        window.scrollBy(0, -viewport.clientHeight);
       }
     }, autoscrollInterval);
   }

--- a/app/assets/javascripts/dashboard.js
+++ b/app/assets/javascripts/dashboard.js
@@ -8,8 +8,8 @@ $(document).ready(() => {
     if ($('.card-extended--fullscreen')[0]) {
       return;
     }
-    if (document.documentElement.scrollTop > offsetTop) {
-      $('#sticky-head, #sticky-corner').css({ top: (document.documentElement.scrollTop) - offsetTop, position: 'relative' });
+    if ($(document).scrollTop() > offsetTop) {
+      $('#sticky-head, #sticky-corner').css({ top: ($(document).scrollTop()) - offsetTop, position: 'relative' });
     } else {
       $('#sticky-head, #sticky-corner').css({ top: 0, position: 'inherit' });
     }


### PR DESCRIPTION
Se arreglan problemas de incompatibilidad con safari

- Se agrega `autoprefixer-rails` para que tome la propiedad `position: sticky`, y otras si se necesitara
- Se cambia `document.documentElement.scrollTop` por `$(document).scrollTop()`
- Se cambia `document.documentElement.scrollBy(...)` por `window.scrollBy(...)`
