### PR TITLE
fix(github-pr-service): get repo name from repository instead of PR

### DIFF
--- a/spec/services/github_pull_request_service_spec.rb
+++ b/spec/services/github_pull_request_service_spec.rb
@@ -137,7 +137,7 @@ describe GithubPullRequestService do
           allow(BuildOctokitClient).to receive(:for).with(token: token, per_page: 20)
                                                     .and_return(client)
           allow(client).to receive(:pull_request).with(
-            github_pr_response_merged.head.repo.full_name,
+            repository.full_name,
             github_pr_response_merged.number
           ).and_return(github_single_pr)
         end


### PR DESCRIPTION
`ImportPullRequestJob` se caía cuando había un PR desde un fork, ya que [aquí](https://github.com/platanus/froggo/blob/6fedc64dd5862f873e05911d968242f136a0417a/app/services/github_pull_request_service.rb#L67) antes se sacaba el nombre del repo desde la PR, lo que correspondía al repo fork, no el original.

Se probó en staging y funciona. En la imágen `testorg225/testrepo3 = repository.full_name` y `difernandez/testrepo3 = github_pull_request.head.repo.full_name`

![image](https://user-images.githubusercontent.com/12057523/49670441-7fe0ec80-fa43-11e8-8e2b-f3414a34fe4f.png)
