### PR TITLE
Feat/delete users at sync

### DIFF
--- a/app/jobs/organization_sync_job.rb
+++ b/app/jobs/organization_sync_job.rb
@@ -5,6 +5,7 @@ class OrganizationSyncJob < ApplicationJob
       GithubOrgMembershipService.new(token: token)
                                 .import_all_from_organization(org_sync.organization)
       GithubRepositoryService.new(token: token).import_all_from_organization(org_sync.organization)
+      OrganizationCleanerService.new(token: token).clean(org_sync.organization)
       org_sync.complete!
     rescue
       org_sync.fail!

--- a/app/services/github_org_membership_service.rb
+++ b/app/services/github_org_membership_service.rb
@@ -9,6 +9,15 @@ class GithubOrgMembershipService < PowerTypes::Service.new(:token)
     end
   end
 
+  def ex_members_ids(org)
+    org.members.where.not(gh_id: github_org_members(org).map(&:id)).pluck(:id)
+  end
+
+  def delete_ex_members(org, ids)
+    org.organization_memberships.where(github_user_id: ids).destroy_all
+    org.members.where(id: ids).destroy_all
+  end
+
   private
 
   def github_org_members(org)

--- a/app/services/github_pull_request_review_service.rb
+++ b/app/services/github_pull_request_review_service.rb
@@ -32,6 +32,10 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
     end
   end
 
+  def delete_prs_reviews(pr_ids)
+    PullRequestReview.where(pull_request_id: pr_ids).destroy_all
+  end
+
   private
 
   def github_pull_request_reviews(pull_request)

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -35,6 +35,10 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
     pull_request
   end
 
+  def delete_prs(pr_ids)
+    PullRequest.where(id: pr_ids).destroy_all
+  end
+
   private
 
   def github_pull_requests(repository, page: nil)

--- a/app/services/organization_cleaner_service.rb
+++ b/app/services/organization_cleaner_service.rb
@@ -1,0 +1,39 @@
+class OrganizationCleanerService < PowerTypes::Service.new(:token)
+  def clean(organization)
+    ex_memb_ids = ex_members_gh_ids(organization)
+    prs_ids = prs_ids_to_delete(ex_memb_ids)
+    delete_prs_relations(prs_ids)
+    delete_prs_reviews(prs_ids)
+    delete_prs(prs_ids)
+    delete_ex_members(organization, ex_memb_ids)
+  end
+
+  def prs_ids_to_delete(mem_ids)
+    PullRequestRelation.where(github_user_id: mem_ids)
+                       .or(PullRequestRelation.where(target_user_id: mem_ids))
+                       .pluck(:pull_request_id)
+  end
+
+  def delete_prs_relations(prs_ids_delete)
+    PullRequestRelation.where(pull_request_id: prs_ids_delete).destroy_all
+  end
+
+  private
+
+  def ex_members_gh_ids(organization)
+    GithubOrgMembershipService.new(token: @token).ex_members_ids(organization)
+  end
+
+  def delete_prs_reviews(prs_ids_delete)
+    GithubPullRequestReviewService.new(token: @token).delete_prs_reviews(prs_ids_delete)
+  end
+
+  def delete_prs(prs_ids_delete)
+    GithubPullRequestService.new(token: @token).delete_prs(prs_ids_delete)
+  end
+
+  def delete_ex_members(organization, ex_memb_ids)
+    GithubOrgMembershipService.new(token: @token)
+                              .delete_ex_members(organization, ex_memb_ids)
+  end
+end

--- a/spec/jobs/organization_sync_job_spec.rb
+++ b/spec/jobs/organization_sync_job_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe OrganizationSyncJob, type: :job do
+  describe '#perform' do
+    let(:organization) { double }
+    let(:org_sync) { double(organization: organization, execute!: nil, complete!: nil) }
+    let(:token) { 'token' }
+    let(:gh_ids) { double }
+    let(:prs_ids) { double }
+    let(:perform_now) { OrganizationSyncJob.perform_now(org_sync, token) }
+    let(:repository_service) { double(import_all_from_organization: nil) }
+    let(:org_cleaner_service) { double(clean: nil) }
+    let(:membership_service) do
+      double(import_all_from_organization: nil,
+             ex_members_ids: gh_ids,
+             delete_ex_members: nil)
+    end
+
+    before do
+      allow(GithubRepositoryService).to receive(:new).and_return(repository_service)
+      allow(GithubOrgMembershipService).to receive(:new).and_return(membership_service)
+      allow(OrganizationCleanerService).to receive(:new).and_return(org_cleaner_service)
+    end
+
+    it 'calls GithubOrgMembershipService#import_all_from_organization' do
+      expect(membership_service).to receive(:import_all_from_organization)
+        .with(org_sync.organization).and_return(nil)
+      perform_now
+    end
+
+    it 'calls GithubRepositoryService#import_all_from_organization' do
+      expect(repository_service).to receive(:import_all_from_organization)
+        .with(org_sync.organization).and_return(nil)
+      perform_now
+    end
+  end
+end

--- a/spec/services/github_org_membership_service_spec.rb
+++ b/spec/services/github_org_membership_service_spec.rb
@@ -9,18 +9,28 @@ describe GithubOrgMembershipService do
   let(:service) { build(token: token) }
   let(:client) { double }
   let(:organization) { create(:organization) }
-  let(:github_response) do
-    [
-      double(
-        login: 'TestUser',
-        id: 10,
-        avatar_url: 'user avatar',
-        html_url: 'user html url',
-        email: '',
-        name: ''
-      )
-    ]
+  let(:user) do
+    double(
+      login: 'TestUser',
+      id: 10,
+      avatar_url: 'user avatar',
+      html_url: 'user html url',
+      email: '',
+      name: ''
+    )
   end
+  let(:user2) do
+    double(
+      login: 'TestUser2',
+      id: 20,
+      avatar_url: 'user avatar',
+      html_url: 'user html url',
+      email: '',
+      name: ''
+    )
+  end
+  let(:github_response) { [user] }
+  let(:github_response_2) { [user, user2] }
 
   before do
     expect(BuildOctokitClient).to receive(:for).and_return(client)
@@ -50,6 +60,65 @@ describe GithubOrgMembershipService do
       it "doesn't create new organization membership" do
         expect do
           service.import_all_from_organization(organization)
+          organization.reload
+        end.to change { organization.organization_memberships.count }.by(0)
+      end
+    end
+  end
+
+  describe '#ex_members_ids' do
+    context "when membership doesn't exist" do
+      before do
+        allow(client).to receive(:org_members).with(organization.login)
+                                              .and_return(github_response_2, github_response)
+        service.import_all_from_organization(organization)
+      end
+
+      it 'returns an array with ex_member id' do
+        expect(organization.members.where(id: service.ex_members_ids(organization)).first.gh_id)
+          .to eq(20)
+      end
+    end
+
+    context 'when membership exists' do
+      before do
+        allow(client).to receive(:org_members).with(organization.login).and_return(github_response)
+        service.import_all_from_organization(organization)
+      end
+
+      it 'returns an empty array' do
+        expect(service.ex_members_ids(organization)).to be_empty
+      end
+    end
+  end
+
+  describe '#delete_ex_members' do
+    context "when membership doesn't exist" do
+      before do
+        allow(client).to receive(:org_members).with(organization.login)
+                                              .and_return(github_response_2, github_response)
+        service.import_all_from_organization(organization)
+      end
+
+      let(:ids) { organization.members.where(gh_id: 10) }
+      it 'deletes user' do
+        expect do
+          service.delete_ex_members(organization, ids)
+          organization.reload
+        end.to change { organization.organization_memberships.count }.by(-1)
+      end
+    end
+
+    context 'when membership exists' do
+      let(:ids) { [] }
+      before do
+        allow(client).to receive(:org_members).with(organization.login).and_return(github_response)
+        service.import_all_from_organization(organization)
+      end
+
+      it "doesn't delete user" do
+        expect do
+          service.delete_ex_members(organization, ids)
           organization.reload
         end.to change { organization.organization_memberships.count }.by(0)
       end

--- a/spec/services/github_pull_request_review_service_spec.rb
+++ b/spec/services/github_pull_request_review_service_spec.rb
@@ -120,4 +120,49 @@ describe GithubPullRequestReviewService do
       service.handle_webhook_event(event_request_data)
     end
   end
+
+  describe '#delete_prs_reviews' do
+    context 'with no reviews to delete' do
+      let!(:pr_ids) { [] }
+      it "doesn't delete any pull request review" do
+        expect { service.delete_prs_reviews(pr_ids) }.to change { PullRequestReview.count }.by(0)
+      end
+    end
+
+    context 'with only one review to delete' do
+      let!(:gh_ids) { [10] }
+      let(:pull_request1) { create(:pull_request, gh_id: gh_ids[0]) }
+      let!(:pr_ids) { [pull_request1.id] }
+      let!(:pr_review) do
+        create(:pull_request_review, gh_id: 1, pull_request: pull_request1)
+      end
+
+      it 'deletes pull request review' do
+        expect { service.delete_prs_reviews(pr_ids) }.to change { PullRequestReview.count }.by(-1)
+      end
+    end
+
+    context 'with more than one review to delete' do
+      let!(:gh_ids) { [10, 20, 30] }
+      let(:pull_request1) { create(:pull_request, gh_id: gh_ids[0]) }
+      let(:pull_request2) { create(:pull_request, gh_id: gh_ids[1]) }
+      let(:pull_request3) { create(:pull_request, gh_id: gh_ids[2]) }
+      let!(:pr_ids) { [pull_request1.id, pull_request2.id, pull_request3.id] }
+      let!(:pr_review) do
+        create(:pull_request_review, gh_id: 1, pull_request: pull_request1)
+      end
+
+      let!(:pr_review2) do
+        create(:pull_request_review, gh_id: 2, pull_request: pull_request2)
+      end
+
+      let!(:pr_review3) do
+        create(:pull_request_review, gh_id: 3, pull_request: pull_request3)
+      end
+
+      it 'deletes all pull requests reviews' do
+        expect { service.delete_prs_reviews(pr_ids) }.to change { PullRequestReview.count }.by(-3)
+      end
+    end
+  end
 end

--- a/spec/services/github_pull_request_service_spec.rb
+++ b/spec/services/github_pull_request_service_spec.rb
@@ -221,4 +221,33 @@ describe GithubPullRequestService do
       service.handle_webhook_event(event_request_data)
     end
   end
+
+  describe '#delete_prs' do
+    context 'with no pull request to delete' do
+      let!(:gh_ids) { [] }
+      it "doesn't delete any pull request" do
+        expect { service.delete_prs(gh_ids) }.to change { PullRequest.count }.by(0)
+      end
+    end
+
+    context 'with only one pull request to delete' do
+      let!(:gh_ids) { [10] }
+      let!(:pull_request) { create(:pull_request, gh_id: gh_ids.first) }
+      let(:pr_ids) { [pull_request.id] }
+      it 'deletes pull request' do
+        expect { service.delete_prs(pr_ids) }.to change { PullRequest.count }.by(-1)
+      end
+    end
+
+    context 'with more than one pull request to delete' do
+      let!(:gh_ids) { [10, 20, 30] }
+      let!(:pull_request1) { create(:pull_request, gh_id: gh_ids.first) }
+      let!(:pull_request2) { create(:pull_request, gh_id: gh_ids[1]) }
+      let!(:pull_request3) { create(:pull_request, gh_id: gh_ids[2]) }
+      let(:pr_ids) { [pull_request1.id, pull_request2.id, pull_request3.id] }
+      it 'deletes all pull requests' do
+        expect { service.delete_prs(pr_ids) }.to change { PullRequest.count }.by(-3)
+      end
+    end
+  end
 end

--- a/spec/services/organization_cleaner_service_spec.rb
+++ b/spec/services/organization_cleaner_service_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+describe OrganizationCleanerService do
+  let(:token) { 'blubli' }
+  let(:service) { build(token: token) }
+  let(:organization) { double }
+  let(:pullRequestReviewService) { double(delete_prs_reviews: nil) }
+  let(:pullRequestService) { double(delete_prs: nil) }
+  let(:gh_ids) { double }
+  let(:prs_ids) { double }
+  let(:membershipService) do
+    double(import_all_from_organization: nil,
+           ex_members_ids: gh_ids,
+           delete_ex_members: nil)
+  end
+
+  def build(*_args)
+    described_class.new(*_args)
+  end
+
+  describe '#clean' do
+    before do
+      allow(service).to receive(:prs_ids_to_delete).and_return(prs_ids)
+      allow(service).to receive(:delete_prs_relations).and_return(nil)
+      allow(GithubPullRequestService).to receive(:new).and_return(pullRequestService)
+      allow(GithubPullRequestReviewService).to receive(:new).and_return(pullRequestReviewService)
+      allow(GithubOrgMembershipService).to receive(:new).and_return(membershipService)
+    end
+
+    it 'calls GithubPullRequestService#delete_prs' do
+      expect(pullRequestService).to receive(:delete_prs).with(prs_ids)
+      service.clean(organization)
+    end
+
+    it 'calls GithubPullRequestReviewService#delete_prs' do
+      expect(pullRequestReviewService).to receive(:delete_prs_reviews).with(prs_ids)
+      service.clean(organization)
+    end
+
+    it 'calls GithubOrgMembershipService#delete_ex_members' do
+      expect(membershipService).to receive(:delete_ex_members)
+        .with(organization, gh_ids).and_return(nil)
+      service.clean(organization)
+    end
+  end
+
+  describe '#prs_ids_to_delete' do
+    let(:pull_request) { create(:pull_request) }
+    context 'when ex_mems_gh_ids is a empty list' do
+      let(:ex_mems_gh_ids) { [] }
+      it 'returns an empty array' do
+        expect(service.prs_ids_to_delete(ex_mems_gh_ids)).to eq([])
+      end
+    end
+
+    context 'when ex_mems_gh_ids is not empty' do
+      let!(:deleted_mem) { create(:github_user) }
+      let!(:mem) { create(:github_user) }
+      let(:ex_mems_gh_ids) { [deleted_mem.id] }
+      context 'when exists related pr to delete' do
+        let!(:pull_request1) { create(:pull_request, owner: deleted_mem) }
+        let!(:pull_request2) { create(:pull_request, owner: mem) }
+        let!(:pr_relation1) do
+          create(:pull_request_relation, pull_request: pull_request1, github_user: deleted_mem)
+        end
+        let!(:pr_relation2) do
+          create(:pull_request_relation, pull_request: pull_request2, github_user: mem)
+        end
+
+        it 'returns array with only related prs ids' do
+          expect(service.prs_ids_to_delete(ex_mems_gh_ids)).to eq([pull_request1.id])
+        end
+      end
+
+      context "when doesn't exist related pr to delete" do
+        it 'returns an empty array' do
+          expect(service.prs_ids_to_delete(ex_mems_gh_ids)).to eq([])
+        end
+      end
+    end
+  end
+
+  describe '#delete_prs_relations' do
+    context 'with no relations to delete' do
+      let!(:pr_ids) { [] }
+      it "doesn't delete any pull request review" do
+        expect { service.delete_prs_relations(pr_ids) }.to \
+          change { PullRequestRelation.count }.by(0)
+      end
+    end
+
+    context 'with only one relations to delete' do
+      let!(:gh_ids) { [10] }
+      let(:pull_request1) { create(:pull_request, gh_id: gh_ids[0]) }
+      let!(:pr_ids) { [pull_request1.id] }
+      let!(:pr_review) do
+        create(:pull_request_relation, pull_request: pull_request1)
+      end
+
+      it 'deletes pull request relations' do
+        expect { service.delete_prs_relations(pr_ids) }.to \
+          change { PullRequestRelation.count }.by(-1)
+      end
+    end
+
+    context 'with more than one relations to delete' do
+      let!(:gh_ids) { [10, 20, 30] }
+      let(:pull_request1) { create(:pull_request, gh_id: gh_ids[0]) }
+      let(:pull_request2) { create(:pull_request, gh_id: gh_ids[1]) }
+      let(:pull_request3) { create(:pull_request, gh_id: gh_ids[2]) }
+      let!(:pr_ids) { [pull_request1.id, pull_request2.id, pull_request3.id] }
+      let!(:pr_relation) do
+        create(:pull_request_relation, pull_request: pull_request1)
+      end
+
+      let!(:pr_relation2) do
+        create(:pull_request_relation, pull_request: pull_request2)
+      end
+
+      let!(:pr_relation3) do
+        create(:pull_request_relation, pull_request: pull_request3)
+      end
+
+      it 'deletes all pull requests reviews' do
+        expect { service.delete_prs_relations(pr_ids) }.to \
+          change { PullRequestRelation.count }.by(-3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Ahora al hacer `sync` se eliminan los usuarios que no son parte de la organización.

Para manejar esto se creó el servicio `OrganizationCleanerService`. Para borrar un usuario, antes elimina todos los `Pull Request`, `PR Relations` y `PR Reviews` asociados a ese usuario. 

- Al servicio `GithubOrgMembershipService` se le agregaron los métodos `ex_members_ids` y `delete_ex_members`

- Al servicio `GithubPullRequestReviewService` se le agregó el método `delete_prs_reviews`

- Al servicio `GithubPullRequestService` se le agregó el método `delete_prs`