### PR TITLE
Feat/public with filters

### DIFF
--- a/app/assets/stylesheets/app/button.scss
+++ b/app/assets/stylesheets/app/button.scss
@@ -9,6 +9,7 @@
   font-weight: 500;
   height: fit-content;
   line-height: 30px;
+  margin-right: 10px;
   min-width: 91px;
   padding: 2px 5px;
   text-align: center;
@@ -30,5 +31,9 @@
 
   &--disabled {
     cursor: not-allowed;
+  }
+
+  &:last-child {
+    margin-right: 0;
   }
 }

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -276,8 +276,9 @@
     }
 
     &__config {
-      position: absolute;
-      right: 32px;
+      display: flex;
+      flex: 1;
+      justify-content: flex-end;
       margin-top: 18px;
     }
 

--- a/app/views/organizations/_card_header.html.erb
+++ b/app/views/organizations/_card_header.html.erb
@@ -52,11 +52,14 @@
       </dropdown>
     <% end %>
   <% end %>
-  <% if @is_admin && !only_organization%>
-    <div class="card-extended__config">
+  <div class="card-extended__config">
+    <% if @is_admin && !only_organization%>
       <a class="button" href="<%= settings_organization_path(@github_organization[:login]) %>">
         <%= t('messages.dashboard.settings') %>
       </a>
-    </div>
-  <% end %>
+    <% end %>
+    <a class="button" href="<%= public_organization_path(name: @github_organization[:login], user_ids: @team_members_ids, month_limit: @corrmat.limit) %>">
+      <%= "Dashboard Publico"  %>
+    </a>
+  </div>
 </div>


### PR DESCRIPTION
Se habilita el dashboard público para equipos y filtro de meses

**Dashboard de un usuario:**
![image](https://user-images.githubusercontent.com/12057523/50026421-acf34900-ffc7-11e8-9753-79c6ef5e45d9.png)

**Dashboard público:**
![image](https://user-images.githubusercontent.com/12057523/50026515-03f91e00-ffc8-11e8-9615-e896a6cdacb7.png)



- Como no se guarda en DB los equipos, y en modo público no se puede acceder a ellos a través de github, se pasan como query params las ids de los usuarios del team
- Se agrega un botón al dashboard para ir al dashboard público con los filtros actuales

Posteriormente, la idea es asociar un token a una organización y conjunto de usuarios, y usar eso en la URL.