### PR TITLE
Determinar membresía de organización para obtener equipos a través de la db

### DIFF
--- a/app/controllers/github_users_controller.rb
+++ b/app/controllers/github_users_controller.rb
@@ -4,7 +4,7 @@ class GithubUsersController < ApplicationController
   def show
     @github_user = GithubUser.find(params[:id])
     @github_session = github_session
-    @teams = @github_session.fetch_teams_for_user(@github_user.login)
+    @teams = @github_session.fetch_teams_for_user(@github_user)
   end
 
   # GET /me

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -6,6 +6,9 @@ class GithubUser < ApplicationRecord
   has_many :pull_requests_reviewed, through: :pull_request_reviews, source: :pull_request
   has_many :pull_requests_merged, class_name: 'PullRequest', foreign_key: :merged_by_id
 
+  has_many :organization_memberships
+  has_many :organizations, through: :organization_memberships, source: :organization
+
   validates :gh_id, presence: true
   validates :login, presence: true
 end

--- a/app/values/github_session.rb
+++ b/app/values/github_session.rb
@@ -51,14 +51,12 @@ class GithubSession
     end
   end
 
-  def fetch_teams_for_user(github_login)
+  def fetch_teams_for_user(github_user)
     teams = []
-    client.organizations(github_login).each do |github_organization|
+    github_user.organizations.each do |organization|
       begin
-        teams << get_teams(
-          Organization.find_by!(gh_id: github_organization[:id])
-        )
-      rescue Octokit::Error, ActiveRecord::RecordNotFound
+        teams << get_teams(organization)
+      rescue Octokit::Error
         # Octokit::Error Thrown, for example, when `octokit_client` has
         # no visibility of the organization's teams. Such teams are ignored.
       end


### PR DESCRIPTION
Si un miembro de una organización se mete a ver el perfil de otro miembro de la misma organización, entonces _sí_ debería poder saber si este otro miembro es o no miembro de la organización.

[Octokit::Client#organizations](http://octokit.github.io/octokit.rb/Octokit/Client/Organizations.html#organizations-instance_method) sólo devuelve las organizaciones para las que el usuario ha hecho pública su membresía, independiente de si el cliente representa un miembro de la misma organización.

Ahora se ocupa el conocimiento que se tiene en la db para pedir las organizaciones de un usuario.