### PR TITLE
Determinar membresía de organización para obtener equipos a través de la db

### DIFF
--- a/app/controllers/github_users_controller.rb
+++ b/app/controllers/github_users_controller.rb
@@ -4,7 +4,7 @@ class GithubUsersController < ApplicationController
   def show
     @github_user = GithubUser.find(params[:id])
     @github_session = github_session
-    @teams = @github_session.fetch_teams_for_user(@github_user.login)
+    @teams = @github_session.fetch_teams_for_user(@github_user)
   end
 
   # GET /me

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -6,6 +6,9 @@ class GithubUser < ApplicationRecord
   has_many :pull_requests_reviewed, through: :pull_request_reviews, source: :pull_request
   has_many :pull_requests_merged, class_name: 'PullRequest', foreign_key: :merged_by_id
 
+  has_many :organization_memberships
+  has_many :organizations, through: :organization_memberships, source: :organization
+
   validates :gh_id, presence: true
   validates :login, presence: true
 end

--- a/app/values/github_session.rb
+++ b/app/values/github_session.rb
@@ -51,14 +51,12 @@ class GithubSession
     end
   end
 
-  def fetch_teams_for_user(github_login)
+  def fetch_teams_for_user(github_user)
     teams = []
-    client.organizations(github_login).each do |github_organization|
+    github_user.organizations.each do |organization|
       begin
-        teams << get_teams(
-          Organization.find_by!(gh_id: github_organization[:id])
-        )
-      rescue Octokit::Error, ActiveRecord::RecordNotFound
+        teams << get_teams(organization)
+      rescue Octokit::Error
         # Octokit::Error Thrown, for example, when `octokit_client` has
         # no visibility of the organization's teams. Such teams are ignored.
       end

--- a/spec/values/github_session_spec.rb
+++ b/spec/values/github_session_spec.rb
@@ -80,33 +80,34 @@ RSpec.describe GithubSession, type: :class do
 
   describe 'fetch_teams_for_user' do
     context 'when no organizations found' do
-      before { allow(client).to receive(:organizations).and_return([]) }
-      it { expect(subject.fetch_teams_for_user('login')).to be_empty }
+      let(:user) { create(:github_user) }
+      before { allow(user).to receive(:organizations).and_return([]) }
+      it { expect(subject.fetch_teams_for_user(user)).to be_empty }
     end
 
     context 'when organizations have teams' do
       let(:teams) do
-        create_team = ->(id, name) { { id: id, name: name, slug: name } }
-        (0...4).map { |id| create_team.call(id, "team-#{id}") }
+        Array.new(4).map { double('team') }
       end
 
-      let(:github_organizations) do
-        [{ id: 0 }, { id: 1 }]
+      let(:user) { create(:github_user) }
+
+      let(:organizations) do
+        [create(:organization), create(:organization)]
       end
 
       let(:org_0_teams) { [teams[0], teams[1]] }
       let(:org_1_teams) { [teams[2], teams[3]] }
 
       before do
-        allow(Organization).to receive(:find_by!).and_return(create(:organization))
-        allow(client).to \
-          receive(:organizations).and_return(github_organizations)
+        allow(user).to \
+          receive(:organizations).and_return(organizations)
         allow(subject).to \
           receive(:get_teams).and_return(org_0_teams, org_1_teams)
       end
 
       it 'returns teams' do
-        expect(subject.fetch_teams_for_user('some_login'))
+        expect(subject.fetch_teams_for_user(user))
           .to eq([*org_0_teams, *org_1_teams])
       end
     end


### PR DESCRIPTION
Si un miembro de una organización se mete a ver el perfil de otro miembro de la misma organización, entonces _sí_ debería poder saber si este otro miembro es o no miembro de la organización.

[Octokit::Client#organizations](http://octokit.github.io/octokit.rb/Octokit/Client/Organizations.html#organizations-instance_method) sólo devuelve las organizaciones para las que el usuario ha hecho pública su membresía, independiente de si el cliente representa un miembro de la misma organización.

Ahora se ocupa el conocimiento que se tiene en la db para pedir las organizaciones de un usuario.