### PR TITLE
Redirigir a la página de perfil del usuario si ya está loggeado

### DIFF
--- a/app/controllers/concerns/github_authenticable.rb
+++ b/app/controllers/concerns/github_authenticable.rb
@@ -11,4 +11,8 @@ module GithubAuthenticable
   def github_session
     @github_session ||= GithubSession.new(cookies)
   end
+
+  def github_user
+    @github_user ||= github_session.user
+  end
 end

--- a/app/controllers/github_users_controller.rb
+++ b/app/controllers/github_users_controller.rb
@@ -9,7 +9,7 @@ class GithubUsersController < ApplicationController
 
   # GET /me
   def me
-    redirect_to user_path(GithubUser.find_by!(login: github_session.name))
+    redirect_to user_path(github_session.user)
   rescue ActiveRecord::RecordNotFound
     redirect_to root_path
   end

--- a/app/controllers/github_users_controller.rb
+++ b/app/controllers/github_users_controller.rb
@@ -2,14 +2,13 @@ class GithubUsersController < ApplicationController
   before_action :authenticate_github_user
 
   def show
-    @github_user = GithubUser.find(params[:id])
-    @github_session = github_session
-    @teams = @github_session.fetch_teams_for_user(@github_user)
+    @github_user = github_user
+    @teams = @github_session.fetch_teams_for_user @github_user
   end
 
   # GET /me
   def me
-    redirect_to user_path(github_session.user)
+    redirect_to user_path(github_user)
   rescue ActiveRecord::RecordNotFound
     redirect_to root_path
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,8 @@
 class HomeController < ApplicationController
   def index
     @user_logged_in = github_session.valid?
-
     @org_redirect = if @user_logged_in
-                      github_session.froggo_path || organizations_path
+                      user_path github_session.user
                     else
                       github_authenticate_path
                     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,10 +1,10 @@
 class HomeController < ApplicationController
   def index
     @user_logged_in = github_session.valid?
-    @org_redirect = if @user_logged_in
-                      user_path github_session.user
-                    else
-                      github_authenticate_path
-                    end
+    @request_login_url = if @user_logged_in
+                           user_path github_user
+                         else
+                           github_authenticate_path
+                         end
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -122,7 +122,7 @@ class OrganizationsController < ApplicationController
   end
 
   def get_matrix(org_id, user_ids, month_limit)
-    corrmat = CorrelationMatrix.new(org_id, user_ids, github_session.name, month_limit)
+    corrmat = CorrelationMatrix.new(org_id, user_ids, github_session.user.login, month_limit)
     corrmat.fill_matrix
     corrmat.min_ranking_indexes
     corrmat

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -122,7 +122,7 @@ class OrganizationsController < ApplicationController
   end
 
   def get_matrix(org_id, user_ids, month_limit)
-    corrmat = CorrelationMatrix.new(org_id, user_ids, github_session.user.login, month_limit)
+    corrmat = CorrelationMatrix.new(org_id, user_ids, github_user.login, month_limit)
     corrmat.fill_matrix
     corrmat.min_ranking_indexes
     corrmat

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,7 @@
     <h1 class="c-presentation__title"><%= t('messages.home.title') %></h1>
     <h3 class="c-presentation__sub-title"><%= t('messages.home.subtitle') %></h3>
     <div class="c-presentation__github-login">
-      <a class="c-github-login" href="<%= @org_redirect %>">
+      <a class="c-github-login" href="<%= @login_button_url %>">
         <span class="c-github-login__logo-container">
           <img class="c-github-login__logo" src="<%= image_path('github-mark.png') %>"/>
         </span>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -3,10 +3,10 @@
     <%= link_to root_path, class: 'header__logo-container' do %>
       <%= image_tag 'froggo-logo.svg', class: 'header__logo' %>
     <% end %>
-    <% unless @github_session.nil? %>
+    <% unless @github_user.nil? %>
       <div class="header__menu-container">
         <dropdown class="user-menu header__user-menu">
-          <img class="user-menu__image" slot="btn" src="<%= @github_session.user.avatar_url %>"/>
+          <img class="user-menu__image" slot="btn" src="<%= @github_user.avatar_url %>"/>
           <div class="user-menu__body" slot="body">
             <%= link_to t('messages.header.close_session'), close_session_path, class: 'user-menu__option'%>
           </div>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -6,7 +6,7 @@
     <% unless @github_session.nil? %>
       <div class="header__menu-container">
         <dropdown class="user-menu header__user-menu">
-          <img class="user-menu__image" slot="btn" src="<%= @github_session.avatar_url %>"/>
+          <img class="user-menu__image" slot="btn" src="<%= @github_session.user.avatar_url %>"/>
           <div class="user-menu__body" slot="body">
             <%= link_to t('messages.header.close_session'), close_session_path, class: 'user-menu__option'%>
           </div>

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe HomeController, type: :controller do
   describe "GET #index" do
     let(:user) { create(:github_user) }
-    let(:github_session) { double(:github_session) }
+    let(:valid) { true }
+    let(:github_session) { double(:github_session, valid?: valid) }
 
     before do
       allow(subject).to receive(:github_session).and_return(github_session)
@@ -11,23 +12,21 @@ RSpec.describe HomeController, type: :controller do
 
     context "when user is authenticated" do
       before do
-        allow(github_session).to receive(:valid?) { true }
         allow(github_session).to receive(:user) { user }
+        get :index
       end
 
-      it do
-        get :index
-        expect(response).to have_http_status(:success)
-      end
+      it { expect(response).to have_http_status(:success) }
+      it { expect(assigns(:request_login_url)).to eq(user_path(user)) }
     end
 
     context "when user is not authenticated" do
-      before { allow(github_session).to receive(:valid?) { false } }
+      let(:valid) { false }
 
-      it do
-        get :index
-        expect(response).to have_http_status(:success)
-      end
+      before { get :index }
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(assigns(:request_login_url)).to eq(github_authenticate_path) }
     end
   end
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -2,27 +2,30 @@ require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do
   describe "GET #index" do
-    let(:valid) { true }
-    let!(:github_session) do
-      double(name: 'login', token: 'token', valid?: valid, froggo_path: 'path')
-    end
+    let(:user) { create(:github_user) }
+    let(:github_session) { double(:github_session) }
+
     before do
       allow(subject).to receive(:github_session).and_return(github_session)
-      get :index
     end
 
-    context "when user is not authenticated" do
-      let(:valid) { false }
+    context "when user is authenticated" do
+      before do
+        allow(github_session).to receive(:valid?) { true }
+        allow(github_session).to receive(:user) { user }
+      end
 
-      it "returns http success" do
+      it do
+        get :index
         expect(response).to have_http_status(:success)
       end
     end
 
-    context "when user is authenticated" do
-      let(:valid) { true }
+    context "when user is not authenticated" do
+      before { allow(github_session).to receive(:valid?) { false } }
 
-      it "returns http success" do
+      it do
+        get :index
         expect(response).to have_http_status(:success)
       end
     end

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe OrganizationsController, type: :controller do
     ]
   end
 
+  let(:user) { create(:github_user) }
+
   describe "GET #index" do
     before do
       expect(subject).to receive(:authenticate_github_user).and_return(true)
@@ -71,7 +73,8 @@ RSpec.describe OrganizationsController, type: :controller do
       before do
         org_teams = [{ id: 1, name: 'Core', slug: 'core' },
                      { id: 2, name: 'Extra', slug: 'extra' }]
-        expect(github_session).to receive(:get_teams).with(organization).and_return(org_teams)
+        allow(github_session).to receive(:get_teams).with(organization) { org_teams }
+        allow(github_session).to receive(:user) { user }
       end
       let!(:organization) { create(:organization, gh_id: 101) }
 
@@ -126,7 +129,12 @@ RSpec.describe OrganizationsController, type: :controller do
 
   describe "GET #public" do
     let(:github_session) do
-      double(organizations: github_organizations, name: 'name', save_froggo_path: 'path')
+      double(
+        organizations: github_organizations,
+        name: 'name',
+        save_froggo_path: 'path',
+        user: user
+      )
     end
 
     context "when admin has enabled public dashboard" do


### PR DESCRIPTION
También le hice un pequeño refactor a `github_session`para evitar las llamadas a `set_user` y `set_organization`. Además, ahora se persiste el usuario en `GithubUsers` cuando se loggea.