### PR TITLE
Recordar el último equipo seleccionado en el perfil del usuario

### DIFF
--- a/app/javascript/components/teams-dropdown.vue
+++ b/app/javascript/components/teams-dropdown.vue
@@ -22,18 +22,36 @@ export default {
     return {
       dropdownTitle: this.$t('message.profile.teamsDropdownTitle'),
       noTeamsMessage: this.$t('message.profile.noTeams'),
-      defaultTeamIndex: 0,
     };
   },
-  created() {
+  mounted() {
     const selectedTeam = this.teams[this.defaultTeamIndex];
     if (selectedTeam) {
       this.dispatchComputeScore(selectedTeam);
     }
   },
+  computed: {
+    defaultTeamIndex() {
+      if (!localStorage.mapUserToDefaultTeam) {
+        return 0;
+      }
+      const mapUserToDefaultTeam = JSON.parse(localStorage.mapUserToDefaultTeam);
+      if (!mapUserToDefaultTeam.hasOwnProperty(this.githubLogin)) {
+        return 0;
+      }
+      const teamId = mapUserToDefaultTeam[this.githubLogin];
+      const index = this.teams.findIndex(team => team.id === teamId);
+      if (index >= 0) {
+        return index;
+      }
+
+      return 0;
+    },
+  },
   methods: {
     onItemClicked({ item }) {
       this.dispatchComputeScore(item);
+      this.makeTeamDefault(item);
     },
 
     dispatchComputeScore(team) {
@@ -43,6 +61,15 @@ export default {
         githubUserLogin: this.githubLogin,
         weeksAgo: 1,
       });
+    },
+
+    makeTeamDefault(team) {
+      const mapUserToDefaultTeam =
+        localStorage.mapUserToDefaultTeam ?
+          JSON.parse(localStorage.mapUserToDefaultTeam) :
+          {};
+      mapUserToDefaultTeam[this.githubLogin] = team.id;
+      localStorage.mapUserToDefaultTeam = JSON.stringify(mapUserToDefaultTeam);
     },
   },
   components: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5464,8 +5464,8 @@ vue-template-es2015-compiler@^1.6.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
 vue@^2.5.17:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.6.tgz#dde41e483c11c46a7bf523909f4f2f816ab60d25"
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.7.tgz#254f188e7621d2d19ee28d0c0442c6d21b53ae2d"
 
 vue@^2.5.9:
   version "2.5.9"


### PR DESCRIPTION
Para cada perfil, se recuerda el último equipo (en local storage) que fue seleccionado. Si se vuelve a cargar ese perfil, entonces ese equipo viene seleccionado.
![image](https://user-images.githubusercontent.com/6628178/53257164-3e59f800-36a8-11e9-97b7-f8b7b31dd65b.png)
