### PR TITLE
feat(home): set profile page as default landing page

### DIFF
--- a/app/controllers/github_auth_controller.rb
+++ b/app/controllers/github_auth_controller.rb
@@ -18,7 +18,7 @@ class GithubAuthController < ApplicationController
     if permitted_params[:callback_action] == 'settings'
       redirect_to settings_organization_path(name: permitted_params[:gh_org])
     else
-      redirect_to github_session.froggo_path || organizations_path
+      redirect_to user_path(github_user) || organizations_path
     end
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,10 +1,13 @@
 class HomeController < ApplicationController
+  before_action :redirect_if_already_logged_in
+
   def index
-    @user_logged_in = github_session.valid?
-    @request_login_url = if @user_logged_in
-                           user_path github_user
-                         else
-                           github_authenticate_path
-                         end
+    @request_login_url = github_authenticate_path
+  end
+
+  private
+
+  def redirect_if_already_logged_in
+    redirect_to user_path(github_user) if github_session.valid?
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -9,11 +9,7 @@
           <img class="c-github-login__logo" src="<%= image_path('github-mark.png') %>"/>
         </span>
         <div class="c-github-login__text">
-          <% if @user_logged_in %>
-            <%= t('messages.home.go_to_dashboard').upcase %>
-          <% else %>
-            <%= t('messages.home.connect_github').upcase %>
-          <% end %>
+          <%= t('messages.home.connect_github').upcase %>
         </div>
       </a>
     </div>

--- a/spec/controllers/github_auth_controller_spec.rb
+++ b/spec/controllers/github_auth_controller_spec.rb
@@ -9,12 +9,13 @@ RSpec.describe GithubAuthController, type: :controller do
       double(
         name: 'name',
         set_session: [],
-        froggo_path: path
+        froggo_path: path,
+        user: 1
       )
     end
 
     before do
-      expect(Octokit).to receive(:exchange_code_for_token)
+      allow(Octokit).to receive(:exchange_code_for_token)
         .with(github_return_code, ENV['GH_AUTH_ID'], ENV['GH_AUTH_SECRET'])
         .and_return(token_result)
       allow(subject).to receive(:github_session)
@@ -26,7 +27,7 @@ RSpec.describe GithubAuthController, type: :controller do
         get :callback, params: { client_type: :member, code: github_return_code }
       end
 
-      it { expect(response).to redirect_to(organizations_path) }
+      it { expect(response).to redirect_to(user_path(github_session.user)) }
     end
 
     context 'from home with last path in github session' do
@@ -37,7 +38,7 @@ RSpec.describe GithubAuthController, type: :controller do
       end
 
       it {
-        expect(response).to redirect_to(github_session.froggo_path)
+        expect(response).to redirect_to(user_path(github_session.user))
       }
     end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe HomeController, type: :controller do
         get :index
       end
 
-      it { expect(response).to have_http_status(:success) }
-      it { expect(assigns(:request_login_url)).to eq(user_path(user)) }
+      it { expect(response).to have_http_status(302) }
     end
 
     context "when user is not authenticated" do


### PR DESCRIPTION
Cuando un usuario hace login entra a la pagina de su perfil en vez del dashboard. Si ya estaba logueado se redirige directamente al perfil, sin pasar por el home.