### PR TITLE
fix(header): show authenticated user's avatar in header

### DIFF
--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -6,7 +6,7 @@
     <% unless @github_user.nil? %>
       <div class="header__menu-container">
         <dropdown class="user-menu header__user-menu">
-          <img class="user-menu__image" slot="btn" src="<%= @github_user.avatar_url %>"/>
+          <img class="user-menu__image" slot="btn" src="<%= @github_session.user.avatar_url %>"/>
           <div class="user-menu__body" slot="body">
             <%= link_to t('messages.header.close_session'), close_session_path, class: 'user-menu__option'%>
           </div>


### PR DESCRIPTION
![header arreglado](https://user-images.githubusercontent.com/26115490/54939015-4a82e080-4f06-11e9-9083-0d63d8fc72ff.PNG)

Header arreglado para que muestre la foto de perfil del usuario logeado en vez de la del usuario de la pagina de perfil en que se encuentra.
