### PR TITLE
Agregar google analytics

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,0 +1,8 @@
+<% if Rails.env.production? && Heroku.stage.production? %>
+  <script>
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+    ga('create', 'UA-26580157-8', 'auto');
+    ga('send', 'pageview', location.pathname);
+  </script>
+  <script async src='https://www.google-analytics.com/analytics.js'></script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 
 
     <%= stylesheet_link_tag    'application', media: 'all' %>
+    <%= render 'layouts/google_analytics' %>
     <%= javascript_include_tag 'application' %>
   </head>
 


### PR DESCRIPTION
Se agrega google analytics para trackear los ingresos a los perfiles de los usuarios.