### PR TITLE
feat(user-profile): delete scores from profile and highlight recommendations

### DIFF
--- a/app/assets/stylesheets/app/profile.scss
+++ b/app/assets/stylesheets/app/profile.scss
@@ -10,8 +10,8 @@
   &__header {
     align-items: center;
     display: flex;
-    flex: 1;
-    flex-direction: column;
+    flex: 2;
+    flex-direction: row;
     padding: 0 2%;
   }
 

--- a/app/views/github_users/_profile_card.html.erb
+++ b/app/views/github_users/_profile_card.html.erb
@@ -1,48 +1,39 @@
 <div class="card">
   <div class="profile__section profile__header">
-    <div class="profile__picture">
-      <img src="<%= @github_user.avatar_url %>" />
-    </div>
-    <div class="profile__info">
-      <div class="profile__name">
-        <%= @github_user.name || t('messages.profile.no_name') %>
-      </div>
-      <div class="profile__github-info">
-        <a href="<%= @github_user.html_url %>">
-          <div class="profile__link">
-            <div class="profile__link-icon">
-              <%= octicon "octoface" %>
-            </div>
-            <div>
-              @<%= @github_user.login %>
-            </div>
-          </div>
-        </a>
-        <teams-dropdown
-           github-login="<%= @github_user.login %>"
-           :teams="<%= @teams.to_json %>">
-        </teams-dropdown>
-      </div>
-    </div>
-  </div>
-  <div class="profile__section profile__content">
     <div class="profile__column">
-      <div class="profile__row profile__title">
-        <%= t('messages.profile.your_score') %>
+      <div class="profile__picture">
+        <img src="<%= @github_user.avatar_url %>" />
       </div>
-      <div class="profile__row">
-        <profile-score-rectangle
-          github-login="<%= @github_user.login %>"
-        >
-        </profile-score-rectangle>
-      </div>
-      <div class="profile__row">
-        <div class="profile__text">
-          <%= t('messages.profile.compute_score_explanation') %>
+      <div class="profile__info">
+        <div class="profile__name">
+          <%= @github_user.name || t('messages.profile.no_name') %>
+        </div>
+        <div class="profile__github-info">
+          <a href="<%= @github_user.html_url %>">
+            <div class="profile__link">
+              <div class="profile__link-icon">
+                <%= octicon "octoface" %>
+              </div>
+              <div>
+                @<%= @github_user.login %>
+              </div>
+            </div>
+          </a>
+          <teams-dropdown
+            github-login="<%= @github_user.login %>"
+            :teams="<%= @teams.to_json %>">
+          </teams-dropdown>
         </div>
       </div>
     </div>
-    <review-recommendations>
-    </review-recommendations>
+    <div class="profile__column profile__title">
+      <% if @teams.empty? %>
+        <%= t('messages.profile.no_recommendations') %>
+      <% end %>
+      <review-recommendations>
+      </review-recommendations>
+    </div>
+  </div>
+  <div class="profile__section profile__content">
   </div>
 </div>

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -61,3 +61,4 @@ es-CL:
       your_score: Tu puntaje
       recommended_reviewers: Te recomendamos mandar tu próximo PR a alguna de estas personas
       not_recommended_reviewers: Evita mandarle otro PR a estas personas
+      no_recommendations: No tenemos recomendaciones para ti dado que no perteneces a ningún equipo


### PR DESCRIPTION
- Eliminar el puntaje de la vista del perfil de usuario.

- Información del usuario y recomendaciones en una "misma fila". Si la información del usuario está arriba de las recomendaciones le quita importancia, hay que tratar que se note que las recomendaciones son lo principal de la vista.

- Mensaje a los usuarios sin recomendaciones por no tener equipos

![Screenshot from 2019-04-10 18-11-06](https://user-images.githubusercontent.com/17652944/55917027-0e18db00-5bbc-11e9-8e8e-8b2a3d846078.png)
![Screenshot from 2019-04-10 18-10-23](https://user-images.githubusercontent.com/17652944/55917026-0e18db00-5bbc-11e9-96a2-12abc7c3e98e.png)
