### PR TITLE
fix(requested-reviewers): fix requested_reviewers presence verification

### DIFF
--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -13,7 +13,7 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
     repo = Repository.find_by(gh_id: data_object.repository.id)
 
     pull_request = import_github_pull_request(repo, data_object.pull_request)
-    if data_object.key?("requested_reviewers")
+    if data_object.key?(:requested_reviewers)
       add_requested_reviewers_to_pull_request(
         pull_request,
         data_object.pull_request,

--- a/spec/services/github_pull_request_service_spec.rb
+++ b/spec/services/github_pull_request_service_spec.rb
@@ -203,7 +203,7 @@ describe GithubPullRequestService do
       end
 
       before do
-        allow(event_request_data).to receive(:key?).with('requested_reviewers').and_return(true)
+        allow(event_request_data).to receive(:key?).with(:requested_reviewers).and_return(true)
       end
 
       it "calls import_github_pull_request" do
@@ -230,7 +230,7 @@ describe GithubPullRequestService do
       end
 
       before do
-        allow(event_request_data).to receive(:key?).with('requested_reviewers').and_return(false)
+        allow(event_request_data).to receive(:key?).with(:requested_reviewers).and_return(false)
       end
 
       it "calls import_github_pull_request" do


### PR DESCRIPTION
Al revisar si el payload de la api de Github incluye el field `requested_reviewers` se buscaba la key como string, pero se debe buscar como símbolo.