### PR TITLE
fix(requested-reviewers): fix error when reading github api payload

### DIFF
--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -17,7 +17,7 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
       add_requested_reviewers_to_pull_request(
         pull_request,
         data_object.pull_request,
-        data_object.requested_reviewers
+        data_object.requested_reviewers.users
       )
     end
   end

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -17,7 +17,7 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
       add_requested_reviewers_to_pull_request(
         pull_request,
         data_object.pull_request,
-        data_object.requested_reviewers.users
+        data_object&.requested_reviewers&.users
       )
     end
   end

--- a/spec/services/github_pull_request_service_spec.rb
+++ b/spec/services/github_pull_request_service_spec.rb
@@ -194,7 +194,9 @@ describe GithubPullRequestService do
           action: 'review_requested',
           pull_request: github_pr_response,
           repository: double(id: repository.gh_id),
-          requested_reviewers: [users[1], users[2]]
+          requested_reviewers: double(
+            users: [users[1], users[2]]
+          )
         )
       end
 


### PR DESCRIPTION
Había un error al intentar acceder a la información de los usuarios a los que se les solicita revisar un PR en el payload de la api de Github. Se estaba intentando recuperar la información directamente en el field `requested_reviewers`, pero dentro de este hay que acceder adicionalmente al field `users`.