### PR TITLE
fix(requested_reviewers): change requested_reviewer field reading

### DIFF
--- a/app/services/github_pull_request_review_service.rb
+++ b/app/services/github_pull_request_review_service.rb
@@ -99,9 +99,14 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
   end
 
   def other_team_members_id(owner_id)
+    team_members = client.team_members(DEFAULT_TEAM_ID).map do |member|
+      {
+        id: member.id,
+        login: member.login
+      }
+    end
     team_members_gh_ids =
-      github_session
-      .get_team_members(DEFAULT_TEAM_ID)
+      team_members
       &.pluck(:id)
     GithubUser
       .where(gh_id: team_members_gh_ids)

--- a/app/services/github_pull_request_review_service.rb
+++ b/app/services/github_pull_request_review_service.rb
@@ -73,8 +73,9 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
   end
 
   def get_behaviour(pull_request, gh_pull_request_review)
+    reviewer = GithubUser.find_by(gh_id: gh_pull_request_review.user.id)
     pull_request.pull_request_review_requests.each do |request|
-      if request.github_user_id == gh_pull_request_review.user.id
+      if request.github_user_id === reviewer.id
         recommendations = team_review_request_recommendations(pull_request.owner_id)
         best_recommendations_ids = recommendations[:best].map { |user| user[:gh_id] }
         worst_recommendations_ids = recommendations[:worst].map { |user| user[:gh_id] }

--- a/app/services/github_pull_request_review_service.rb
+++ b/app/services/github_pull_request_review_service.rb
@@ -116,8 +116,8 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
 
   def team_review_request_recommendations(owner_id, organization_dt_id)
     GetReviewRecommendations.for(
-      user_id: owner_id,
-      other_users_id: other_team_members_id(owner_id, organization_dt_id)
+      github_user_id: owner_id,
+      other_users_ids: other_team_members_id(owner_id, organization_dt_id)
     )
   end
 

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -13,11 +13,11 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
     repo = Repository.find_by(gh_id: data_object.repository.id)
 
     pull_request = import_github_pull_request(repo, data_object.pull_request)
-    if data_object.key?(:requested_reviewers)
+    if data_object.action === "review_requested"
       add_requested_reviewers_to_pull_request(
         pull_request,
         data_object.pull_request,
-        data_object&.requested_reviewers&.users
+        data_object.requested_reviewer
       )
     end
   end
@@ -48,15 +48,13 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
     PullRequest.where(id: pr_ids).destroy_all
   end
 
-  def add_requested_reviewers_to_pull_request(pull_request, gh_pull_request, requested_reviewers)
-    requested_reviewers.each do |reviewer|
-      unless PullRequestReviewRequest.find_by(
-        github_user_id: reviewer.id,
-        pull_request_id: pull_request.id
-      )
-        base_params = get_request_base_params(gh_pull_request, reviewer.id)
-        pull_request.pull_request_review_requests.create!(base_params)
-      end
+  def add_requested_reviewers_to_pull_request(pull_request, gh_pull_request, requested_reviewer)
+    unless PullRequestReviewRequest.find_by(
+      github_user_id: requested_reviewer.id,
+      pull_request_id: pull_request.id
+    )
+      base_params = get_request_base_params(gh_pull_request, requested_reviewer.id)
+      pull_request.pull_request_review_requests.create!(base_params)
     end
   end
 

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -49,11 +49,12 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
   end
 
   def add_requested_reviewers_to_pull_request(pull_request, gh_pull_request, requested_reviewer)
+    reviewer = GithubUser.find_by(gh_id: requested_reviewer.id)
     unless PullRequestReviewRequest.find_by(
-      github_user_id: requested_reviewer.id,
+      github_user_id: reviewer.id,
       pull_request_id: pull_request.id
     )
-      base_params = get_request_base_params(gh_pull_request, requested_reviewer.id)
+      base_params = get_request_base_params(gh_pull_request, reviewer.id)
       pull_request.pull_request_review_requests.create!(base_params)
     end
   end

--- a/spec/services/github_pull_request_review_service_spec.rb
+++ b/spec/services/github_pull_request_review_service_spec.rb
@@ -7,44 +7,70 @@ describe GithubPullRequestReviewService do
   let(:service) { build(token: token) }
 
   let(:users) do
-    Array.new(7) do
-      |index| double(
-        id: index + 1,
-        gh_id: index + 1,
-        login: "milla",
-        name: "Milla Jovovich",
-        email: "milla@jovovich.cl",
-        avatar_url: 'url_to_avatar',
-        html_url: 'url_to_html'
+    create_list(
+      :github_user,
+      7,
+      login: 'milla',
+      name: 'Milla Jovovich',
+      email: 'milla@jovovich.cl',
+      avatar_url: 'url_to_avatar',
+      html_url: 'url_to_html'
+    )
+  end
+
+  let(:github_review_response) do
+    double(
+      id: 123,
+      user: double(
+        id: users[0].gh_id,
+        login: users[0].login,
+        name: users[0].name,
+        email: users[0].email,
+        avatar_url: users[0].avatar_url,
+        html_url: users[0].html_url
       )
-    end
-  end
-
-  let!(:github_review_response) do
-    double(
-      id: 123,
-      user: users[0]
     )
   end
 
-  let!(:github_review_response2) do
+  let(:github_review_response2) do
     double(
       id: 123,
-      user: users[3]
+      user: double(
+        id: users[3].gh_id,
+        login: users[3].login,
+        name: users[3].name,
+        email: users[3].email,
+        avatar_url: users[3].avatar_url,
+        html_url: users[3].html_url
+      )
     )
   end
 
-  let!(:github_review_response3) do
+  let(:github_review_response3) do
     double(
       id: 123,
-      user: users[5]
+      user: double(
+        id: users[5].gh_id,
+        login: users[5].login,
+        name: users[5].name,
+        email: users[5].email,
+        avatar_url: users[5].avatar_url,
+        html_url: users[5].html_url
+      )
     )
   end
 
-  let!(:github_review_response4) do
+  let(:github_review_response4) do
     double(
       id: 123,
-      user: users[6]
+      user: double(
+        id: users[6].gh_id,
+        login: users[6].login,
+        name: users[6].name,
+        email: users[6].email,
+        avatar_url: users[6].avatar_url,
+        html_url: users[6].html_url
+      )
     )
   end
 
@@ -75,11 +101,22 @@ describe GithubPullRequestReviewService do
             })
           allow(pull_request).to receive(:pull_request_review_requests)
             .and_return([
-                          double(pull_request_id: 123, github_user_id: 1),
-                          double(pull_request_id: 123, github_user_id: 6),
-                          double(pull_request_id: 123, github_user_id: 7)
+                          create(
+                            :pull_request_review_request,
+                            pull_request_id: pull_request.id,
+                            github_user_id: users[0].id
+                          ),
+                          create(
+                            :pull_request_review_request,
+                            pull_request_id: pull_request.id,
+                            github_user_id: users[5].id
+                          ),
+                          create(
+                            :pull_request_review_request,
+                            pull_request_id: pull_request.id,
+                            github_user_id: users[6].id
+                          )
                         ])
-          users.each { |user| allow(user).to receive(:[]).and_return(user.gh_id) }
         end
 
         it "creates new pull request review" do
@@ -94,7 +131,7 @@ describe GithubPullRequestReviewService do
 
           expect(pull_request_review).to have_attributes(
             gh_id: 123,
-            github_user_id: GithubUser.find_by(gh_id: 1).id
+            github_user_id: users[0].id
           )
         end
 
@@ -102,7 +139,6 @@ describe GithubPullRequestReviewService do
           it "defines behaviour as obedient" do
             service.import_github_pull_request_review(pull_request, github_review_response)
             pull_request_review = PullRequestReview.last
-
             expect(pull_request_review).to have_attributes(
               recommendation_behaviour: "obedient"
             )

--- a/spec/services/github_pull_request_service_spec.rb
+++ b/spec/services/github_pull_request_service_spec.rb
@@ -5,10 +5,16 @@ describe GithubPullRequestService do
 
   let(:service) { build(token: token) }
 
-  let(:users) do
+  let!(:users) do
     Array.new(3) do
       create(:github_user)
     end
+  end
+
+  let(:requested_reviewer) do
+    double(
+      id: users[1].gh_id
+    )
   end
 
   let(:github_pr_response) do
@@ -194,7 +200,7 @@ describe GithubPullRequestService do
           action: 'review_requested',
           pull_request: github_pr_response,
           repository: double(id: repository.gh_id),
-          requested_reviewer: users[1]
+          requested_reviewer: requested_reviewer
         )
       end
 
@@ -210,7 +216,7 @@ describe GithubPullRequestService do
 
       it 'calls add_requested_reviewers_to_pull_request' do
         expect(service).to receive(:add_requested_reviewers_to_pull_request)
-          .with(pull_request, github_pr_response, users[1])
+          .with(pull_request, github_pr_response, requested_reviewer)
           .and_return(nil)
         service.handle_webhook_event(event_request_data)
       end
@@ -271,15 +277,12 @@ describe GithubPullRequestService do
     let!(:pull_request) do
       create(:pull_request, gh_id: 3, title: "Old Title", repository: repository)
     end
-    let(:requested_reviewer) { users[1] }
-
     it 'adds new requested reviewers' do
       service.add_requested_reviewers_to_pull_request(
         pull_request,
         github_pr_response,
         requested_reviewer
       )
-
       expect(pull_request.pull_request_review_requests.length).to eq(1)
     end
 

--- a/spec/services/github_pull_request_service_spec.rb
+++ b/spec/services/github_pull_request_service_spec.rb
@@ -194,18 +194,12 @@ describe GithubPullRequestService do
           action: 'review_requested',
           pull_request: github_pr_response,
           repository: double(id: repository.gh_id),
-          requested_reviewers: double(
-            users: [users[1], users[2]]
-          )
+          requested_reviewer: users[1]
         )
       end
 
       let!(:pull_request) do
         create(:pull_request, gh_id: 3, title: "Old Title", repository: repository)
-      end
-
-      before do
-        allow(event_request_data).to receive(:key?).with(:requested_reviewers).and_return(true)
       end
 
       it "calls import_github_pull_request" do
@@ -216,7 +210,7 @@ describe GithubPullRequestService do
 
       it 'calls add_requested_reviewers_to_pull_request' do
         expect(service).to receive(:add_requested_reviewers_to_pull_request)
-          .with(pull_request, github_pr_response, [users[1], users[2]])
+          .with(pull_request, github_pr_response, users[1])
           .and_return(nil)
         service.handle_webhook_event(event_request_data)
       end
@@ -277,23 +271,23 @@ describe GithubPullRequestService do
     let!(:pull_request) do
       create(:pull_request, gh_id: 3, title: "Old Title", repository: repository)
     end
-    let(:requested_reviewers) { [users[1], users[2]] }
+    let(:requested_reviewer) { users[1] }
 
     it 'adds new requested reviewers' do
       service.add_requested_reviewers_to_pull_request(
         pull_request,
         github_pr_response,
-        requested_reviewers
+        requested_reviewer
       )
 
-      expect(pull_request.pull_request_review_requests.length).to eq(2)
+      expect(pull_request.pull_request_review_requests.length).to eq(1)
     end
 
     it 'pull request review requested has valid data' do
       service.add_requested_reviewers_to_pull_request(
         pull_request,
         github_pr_response,
-        requested_reviewers
+        requested_reviewer
       )
 
       expect(pull_request.pull_request_review_requests.first).to have_attributes(
@@ -306,15 +300,15 @@ describe GithubPullRequestService do
       service.add_requested_reviewers_to_pull_request(
         pull_request,
         github_pr_response,
-        requested_reviewers
+        requested_reviewer
       )
       service.add_requested_reviewers_to_pull_request(
         pull_request,
         github_pr_response,
-        requested_reviewers
+        requested_reviewer
       )
 
-      expect(pull_request.pull_request_review_requests.length).to eq(2)
+      expect(pull_request.pull_request_review_requests.length).to eq(1)
     end
   end
 end


### PR DESCRIPTION
El payload se estaba leyendo de manera incorrecta, el field `requested_reviewer` está en singular, no en plural. Además, se chequea que la acción del evento de Github sea `review_requested` en vez de revisar que exista el field `requested_reviewer`, para determinar si se lleva a cabo o no el método. `add_requested_reviewers_to_pull_request`.
También se cambia la forma de obtener los ids de los miembros del equipo para obtener las recomendaciones de froggo, usando el flag `is_member_of_default_team` de `OrganizationMembership`, en vez de intentar obtenerlos a través del cliente de la api de Github.  
Por último, se usa el `default_team_id` para determinar el equipo en el que se buscan las recomendaciones, en vez de una variable hardcodeada.
![behaviour](https://user-images.githubusercontent.com/26115490/57395762-edca4500-7196-11e9-990e-9f988f154028.PNG)
