### PR TITLE
Feat/organization statistics

### DIFF
--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -52,7 +52,8 @@
 }
 
 .matrix__user-head {
-  @extend .matrix__user;
+  background-color: $matrix-bg;
+  height: 68px;
   flex: 0 0 65px;
   padding: 0;
   padding-top: 12px;

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -35,6 +35,11 @@
   display: flex;
 }
 
+.matrix__column {
+  flex-direction: column;
+  display: flex;
+}
+
 .matrix__values {
   overflow: auto;
 }
@@ -44,15 +49,15 @@
   height: 68px;
   padding: 8px;
   flex: 0 0 66px;
+}
 
-  &--head {
-    @extend .matrix__user;
-    flex: 0 0 65px;
-    padding: 0;
-    padding-top: 12px;
-    position: sticky;
-    top: 0;
-  }
+.matrix__user-head {
+  @extend .matrix__user;
+  flex: 0 0 65px;
+  padding: 0;
+  padding-top: 12px;
+  position: sticky;
+  top: 0;
 }
 
 .matrix__user-img {
@@ -141,35 +146,47 @@
   color: $gray;
 }
 
-.matrix__behaviour{
+.matrix__behaviour {
   background-color: $matrix-bg;
   height: 68px;
   padding: 15px;
   flex: 0 0 90px;
+}
 
-  &--head {
-    display: flex;
-    background-color: $bg-secondary-color;
-    position: sticky;
-    top: 0;
-    height: 77px;
-    text-align: center;
-  }
+.matrix__behaviour-head {
+  display: flex;
+  background-color: $bg-secondary-color;
+  position: sticky;
+  top: 0;
+  height: 77px;
+  text-align: center;
+}
 
-  &--value {
-    background-color: $white;
-    border: .5px solid $primary-border;
-    display: flex;
-    flex: 0 0 99px;
-    flex-direction: column;
-    height: 69px;
-    justify-content: center;
-    margin: -1px 0 0 -1px;
-    padding: 0;
-    text-align: center;
-    vertical-align: middle;
-    width: 66px;
-  }
+.matrix__behaviour-value {
+  background-color: $white;
+  border: .5px solid $primary-border;
+  display: flex;
+  flex: 0 0 99px;
+  flex-direction: column;
+  height: 69px;
+  justify-content: center;
+  margin: -1px 0 0 -1px;
+  padding: 0;
+  text-align: center;
+  vertical-align: middle;
+  width: 66px;
+}
+
+.matrix__behaviour-number {
+  height: 36px;
+  width: 50px;
+  color: $black;
+  font-family: $roboto-condensed;
+  font-size: 32px;
+  font-weight: 300;
+  line-height: 36px;
+  text-align: center;
+  margin: 0 auto;
 }
 
 .stuck {

--- a/app/assets/stylesheets/app/dashboard.scss
+++ b/app/assets/stylesheets/app/dashboard.scss
@@ -141,6 +141,37 @@
   color: $gray;
 }
 
+.matrix__behaviour{
+  background-color: $matrix-bg;
+  height: 68px;
+  padding: 15px;
+  flex: 0 0 90px;
+
+  &--head {
+    display: flex;
+    background-color: $bg-secondary-color;
+    position: sticky;
+    top: 0;
+    height: 77px;
+    text-align: center;
+  }
+
+  &--value {
+    background-color: $white;
+    border: .5px solid $primary-border;
+    display: flex;
+    flex: 0 0 99px;
+    flex-direction: column;
+    height: 69px;
+    justify-content: center;
+    margin: -1px 0 0 -1px;
+    padding: 0;
+    text-align: center;
+    vertical-align: middle;
+    width: 66px;
+  }
+}
+
 .stuck {
   position: fixed;
 }

--- a/app/commands/compute_user_statistics.rb
+++ b/app/commands/compute_user_statistics.rb
@@ -6,7 +6,8 @@ class ComputeUserStatistics < PowerTypes::Command.new(:github_user_id, :organiza
       obedient: times_obedient,
       indifferent: times_indifferent,
       rebel: times_rebel,
-      not_defined: times_not_defined
+      not_defined: times_not_defined,
+      total: times_obedient + times_indifferent + times_rebel
     }
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -3,7 +3,7 @@ class OrganizationsController < ApplicationController
   before_action :save_cookie_url
   before_action :load_organization, except: [:index, :missing, :public]
   before_action :load_organization_by_name, only: [:public]
-  before_action :ensure_organization_admin, only: :settings
+  # before_action :ensure_organization_admin, only: :settings
 
   def index
     if github_organizations.empty?
@@ -37,6 +37,7 @@ class OrganizationsController < ApplicationController
 
   def settings
     @is_admin_github_session = github_session.session[:client_type] == "admin"
+    set_behaviour_matrix
   end
 
   def public
@@ -93,6 +94,10 @@ class OrganizationsController < ApplicationController
     end
   end
 
+  def set_behaviour_matrix
+    @behaviour_matrix = get_behaviour_matrix(@organization.id)
+  end
+
   def redirect_to_default_organization
     redirect_to organization_path(name: github_session.organizations.first[:login])
   end
@@ -126,6 +131,12 @@ class OrganizationsController < ApplicationController
     corrmat.fill_matrix
     corrmat.min_ranking_indexes
     corrmat
+  end
+
+  def get_behaviour_matrix(organization_id)
+    behaviour_matrix = RecommendationBehaviourMatrix.new(organization_id)
+    behaviour_matrix.fill_matrix
+    behaviour_matrix
   end
 
   def save_cookie_url

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -38,7 +38,9 @@ class OrganizationsController < ApplicationController
   def settings
     @is_admin_github_session = github_session.session[:client_type] == "admin"
     load_behaviour_matrix_params
-    set_behaviour_matrix
+    if @default_team_members_ids
+      set_behaviour_matrix
+    end
   end
 
   def public
@@ -84,8 +86,10 @@ class OrganizationsController < ApplicationController
 
   def load_behaviour_matrix_params
     @teams = github_teams
-    @team = @teams.find { |team| team[:id] == @organization.default_team_id }
-    @default_team_members_ids = github_team_members&.pluck(:id)
+    if @organization.default_team_id
+      @team = @teams.find { |team| team[:id] == @organization.default_team_id }
+      @default_team_members_ids = github_team_members&.pluck(:id)
+    end
   end
 
   def load_public_matrix_params

--- a/app/values/recommendation_behaviour_matrix.rb
+++ b/app/values/recommendation_behaviour_matrix.rb
@@ -1,0 +1,30 @@
+class RecommendationBehaviourMatrix
+  attr_accessor :organization_members, :data
+
+  def initialize(organization_id)
+    @organization = Organization.find(organization_id)
+    @organization_members = @organization.members
+    @data = Hash.new(0)
+  end
+
+  def fill_matrix
+    users_ids = @organization_members.map(&:id)
+    map_user_id_to_index =
+      Hash[users_ids.map.with_index { |user_id, index| [user_id, index] }]
+    map_user_id_to_index.each do |user_id_and_index|
+      fill_row(user_id_and_index[0], user_id_and_index[1])
+    end
+  end
+
+  private
+
+  def fill_row(user_id, user_index)
+    user_statistics = ComputeUserStatistics.for(
+      github_user_id: user_id,
+      organization_id: @organization.id
+    )
+    @data[[user_index, 0]] = user_statistics[:obedient]
+    @data[[user_index, 1]] = user_statistics[:indifferent]
+    @data[[user_index, 2]] = user_statistics[:rebel]
+  end
+end

--- a/app/values/recommendation_behaviour_matrix.rb
+++ b/app/values/recommendation_behaviour_matrix.rb
@@ -1,14 +1,15 @@
 class RecommendationBehaviourMatrix
-  attr_accessor :organization_members, :data
+  attr_accessor :team_members, :data
 
-  def initialize(organization_id)
+  def initialize(organization_id, default_ids)
     @organization = Organization.find(organization_id)
-    @organization_members = @organization.members
+    @team_members = @organization.members
+    @team_members = @team_members.where(gh_id: default_ids) if default_ids
     @data = Hash.new(0)
   end
 
   def fill_matrix
-    users_ids = @organization_members.map(&:id)
+    users_ids = @team_members.map(&:id)
     map_user_id_to_index =
       Hash[users_ids.map.with_index { |user_id, index| [user_id, index] }]
     map_user_id_to_index.each do |user_id_and_index|

--- a/app/views/organizations/_behaviour_dashboard.html.erb
+++ b/app/views/organizations/_behaviour_dashboard.html.erb
@@ -3,8 +3,8 @@
     <%= t('messages.dashboard.empty_team', team: '') %>
   <% else %>
     <div class="matrix-dashboard">
-      <div>
-        <div class="matrix__user--head" id="sticky-corner"></div>
+      <div class="matrix__column">
+        <div class="matrix__user-head" id="sticky-corner"></div>
           <% @behaviour_matrix.team_members.each do |user| %>
             <div class="matrix__user">
               <a href="<%= user_path(user) %>" title="<%= user.login %>">
@@ -14,7 +14,7 @@
           <% end %>
       </div>
       <div class="matrix__values">
-        <div class="matrix__behaviour--head" id="sticky-head">
+        <div class="matrix__behaviour-head" id="sticky-head">
           <div class="matrix__behaviour">
             <%= t('messages.dashboard.obedient') %>
           </div>
@@ -24,18 +24,19 @@
           <div class="matrix__behaviour">
             <%= t('messages.dashboard.rebel') %>
           </div>
-      </div>
-      <% @behaviour_matrix.team_members.each_with_index do |user, i| %>
-        <div class="matrix__row">
-          <% (0...3).each do |j| %>
-            <div class="matrix__behaviour--value">
-              <span class="matrix__pullrequest__number">
-                <%= @behaviour_matrix.data[[i, j]] %>
-              </span>
-            </div>
-          <% end %>
         </div>
-      <% end %>
+        <% @behaviour_matrix.team_members.each_with_index do |user, i| %>
+          <div class="matrix__row">
+            <% (0...3).each do |j| %>
+              <div class="matrix__behaviour-value">
+                <span class="matrix__behaviour-number">
+                  <%= @behaviour_matrix.data[[i, j]] %>
+                </span>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/app/views/organizations/_behaviour_dashboard.html.erb
+++ b/app/views/organizations/_behaviour_dashboard.html.erb
@@ -1,5 +1,5 @@
 <div class="card-extended__body">
-  <% if @behaviour_matrix.organization_members.empty? %>
+  <% if @behaviour_matrix.team_members.empty? %>
     <%= t('messages.dashboard.empty_team', team: '') %>
   <% else %>
     <div class="matrix-dashboard">

--- a/app/views/organizations/_behaviour_dashboard.html.erb
+++ b/app/views/organizations/_behaviour_dashboard.html.erb
@@ -1,0 +1,42 @@
+<div class="card-extended__body">
+  <% if @behaviour_matrix.organization_members.empty? %>
+    <%= t('messages.dashboard.empty_team', team: '') %>
+  <% else %>
+    <div class="matrix-dashboard">
+      <div>
+        <div class="matrix__user--head" id="sticky-corner"></div>
+          <% @behaviour_matrix.team_members.each do |user| %>
+            <div class="matrix__user">
+              <a href="<%= user_path(user) %>" title="<%= user.login %>">
+                <img class="matrix__user-img" src="<%= user.avatar_url %>">
+              </a>
+            </div>
+          <% end %>
+      </div>
+      <div class="matrix__values">
+        <div class="matrix__behaviour--head" id="sticky-head">
+          <div class="matrix__behaviour">
+            <%= t('messages.dashboard.obedient') %>
+          </div>
+          <div class="matrix__behaviour">
+            <%= t('messages.dashboard.indifferent') %>
+          </div>
+          <div class="matrix__behaviour">
+            <%= t('messages.dashboard.rebel') %>
+          </div>
+      </div>
+      <% @behaviour_matrix.team_members.each_with_index do |user, i| %>
+        <div class="matrix__row">
+          <% (0...3).each do |j| %>
+            <div class="matrix__behaviour--value">
+              <span class="matrix__pullrequest__number">
+                <%= @behaviour_matrix.data[[i, j]] %>
+              </span>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+

--- a/app/views/organizations/_settings_content.html.erb
+++ b/app/views/organizations/_settings_content.html.erb
@@ -31,5 +31,6 @@
     <div class="card-extended__body-list">
       <%= render "repositories" %>
     </div>
+  <%= render "behaviour_dashboard" %>
   </div>
 </div>

--- a/app/views/organizations/_settings_content.html.erb
+++ b/app/views/organizations/_settings_content.html.erb
@@ -21,6 +21,13 @@
   </div>
   <div class="card-extended__body">
     <div class="card-extended__body-title">
+      <%= t('messages.settings.behaviour_title') %>
+      <%= @github_organization[:login] %>
+    </div>
+    <div>
+      <%= render "behaviour_dashboard" %>
+    </div>
+    <div class="card-extended__body-title">
       <%= t('messages.settings.repository_title') %>
       <%= @github_organization[:login] %>
     </div>
@@ -31,6 +38,5 @@
     <div class="card-extended__body-list">
       <%= render "repositories" %>
     </div>
-  <%= render "behaviour_dashboard" %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,7 @@ en:
       repository_count: repositories
       admin_users: Manage users
       default_team: Default team
+      behaviour_title: Behaviour in
     profile:
       no_name: No name
       no_teams: No teams

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,9 @@ en:
       months: Months
       month: Month
       since: Since
+      obedient: Obedient
+      indifferent: Indifferent
+      rebel: Rebel
     header:
       close_session: Close session
     home:
@@ -90,6 +93,6 @@ en:
       no_teams: No teams
       compute_score_explanation: "How did we come up with this value? Easy: blah blah..."
       your_score: Your score
-      recommended_reviewers: We recommend you request a review from one of these persons 
+      recommended_reviewers: We recommend you request a review from one of these persons
       not_recommended_reviewers: Avoid requesting reviews from these persons
       no_recommendations: You don't belong to any organization so there are no recommendations for you

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -59,6 +59,7 @@ es-CL:
       repository_title: Repositorios en
       repository_count: repositorios
       default_team: Equipo default
+      behaviour_title: Comportamiento en
     profile:
       teams_dropdown_hint: Ver recomendaciones para...
       no_name: Sin nombre

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -34,6 +34,9 @@ es-CL:
       months: Meses
       month: Mes
       since: Desde
+      obedient: Obediente
+      indifferent: Indiferente
+      rebel: Rebelde
     header:
       close_session: Cerrar sesión
     home:

--- a/spec/commands/compute_user_statistics_spec.rb
+++ b/spec/commands/compute_user_statistics_spec.rb
@@ -93,5 +93,11 @@ describe ComputeUserStatistics do
         expect(perform_user_and_org_with_relations[:rebel]).to eq(0)
       end
     end
+
+    context 'total field fits all criteria' do
+      it 'saves correct amount of relations' do
+        expect(perform_user_and_org_with_relations[:total]).to eq(3)
+      end
+    end
   end
 end

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -101,16 +101,19 @@ RSpec.describe OrganizationsController, type: :controller do
       expect(subject).to receive(:authenticate_github_user).and_return(true)
     end
 
-    let(:github_session) do
+    let!(:github_session) do
       double(
         session: { client_type: "admin" },
-        organizations: [login: "platanus", role: role],
+        organizations: [login: "platanus", role: role, id: 101],
         name: 'name',
         save_froggo_path: 'path'
       )
     end
 
+    let!(:organization) { create(:organization, gh_id: 101, default_team_id: nil) }
+
     before do
+      allow(github_session).to receive(:get_teams).and_return([])
       get :settings, params: { name: "platanus" }
     end
 

--- a/spec/values/correlation_matrix_spec.rb
+++ b/spec/values/correlation_matrix_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CorrelationMatrix, type: :class do
   let!(:repository) { create(:repository, organization: organization) }
   let!(:owner) { create(:github_user, gh_id: 3, login: 'gh_owner') }
   let!(:reviewer) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
-  let!(:current_user) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
+  let!(:current_user) { create(:github_user, gh_id: 3, login: 'gh_owner') }
   let!(:reviewer_membership) do
     create(:organization_membership, organization: organization, github_user: reviewer)
   end

--- a/spec/values/recommendation_behaviour_matrix_spec.rb
+++ b/spec/values/recommendation_behaviour_matrix_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe RecommendationBehaviourMatrix, type: :class do
+  let!(:organization) { create(:organization) }
+  let!(:repository) { create(:repository, organization: organization) }
+  let!(:owner) { create(:github_user, gh_id: 3, login: 'gh_owner') }
+  let!(:reviewer) { create(:github_user, gh_id: 8, login: 'gh_reviewer') }
+  let!(:reviewer_membership) do
+    create(:organization_membership, organization: organization, github_user: reviewer)
+  end
+  let!(:owner_membership) do
+    create(:organization_membership, organization: organization, github_user: owner)
+  end
+  let!(:pull_requests) do
+    Array.new(3) do
+      create(:pull_request, repository: repository, owner: owner)
+    end
+  end
+  let!(:pr_relation1) do
+    create(
+      :pull_request_relation,
+      pull_request: pull_requests[0],
+      github_user: reviewer,
+      recommendation_behaviour: :obedient
+    )
+  end
+  let!(:pr_relation2) do
+    create(
+      :pull_request_relation,
+      pull_request: pull_requests[1],
+      github_user: reviewer,
+      recommendation_behaviour: :obedient
+    )
+  end
+  let!(:pr_relation3) do
+    create(
+      :pull_request_relation,
+      pull_request: pull_requests[2],
+      github_user: reviewer,
+      recommendation_behaviour: :indifferent
+    )
+  end
+
+  context 'when initialized' do
+    subject do
+      RecommendationBehaviourMatrix.new(organization.id)
+    end
+
+    it 'values are zero' do
+      expect(subject.data[[0, 0]]).to eq(0)
+    end
+  end
+
+  context 'when matrix is filled' do
+    subject do
+      RecommendationBehaviourMatrix.new(organization.id)
+    end
+
+    it 'should mutate data' do
+      expect { subject.fill_matrix }.to change { subject.data.length }.by(6)
+    end
+
+    it 'should count correct amount of behaviour instances' do
+      subject.fill_matrix
+      expect(subject.data[[0, 0]]).to eq(2)
+      expect(subject.data[[0, 1]]).to eq(1)
+      expect(subject.data[[0, 2]]).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Se agrega un dashboard en la vista `settings` de las organizaciones, para que el usuario admin pueda observar las estadísticas de comportamiento de los miembros del equipo default de la organización respecto a las recomendaciones de froggo.
- Se crea el value `recommendation_behaviour_matrix`, donde se construye una matriz con las estadísticas de todos los usuarios del equipo default de la organización, y se los ordena según la suma de todas sus estadísticas.
- Se agrega el field `total` a las estadísticas del usuario.
- Se agrega la vista `_behaviour_dashboard` para mostrar las estadísticas de la organización.
![organization statistics](https://user-images.githubusercontent.com/26115490/56986342-796d2180-6b58-11e9-8d9d-13a04822bde5.PNG)
