### PR TITLE
Feat/default team membership

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -16,6 +16,8 @@ class Api::V1::OrganizationsController < Api::V1::BaseController
 
   def update
     if organization.update_attributes(update_params)
+      GithubOrgMembershipService.new(token: @github_session.token)
+                                .import_default_team_members(organization)
       render json: { response: 'Updated' }, status: 200
     else
       render json: { response: 'Bad request', errors: @user.errors.messages }, status: 400

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::OrganizationsController < Api::V1::BaseController
   before_action :authenticate_github_user
-  # before_action :ensure_organization_admin
+  before_action :ensure_organization_admin
+  after_action :update_organization_default_team_memberships, only: [:update]
 
   def sync
     OrganizationSyncJob.perform_later(
@@ -16,10 +17,6 @@ class Api::V1::OrganizationsController < Api::V1::BaseController
 
   def update
     if organization.update_attributes(update_params)
-      if organization.saved_change_to_attribute?(:default_team_id)
-        GithubOrgMembershipService.new(token: @github_session.token)
-                                  .import_default_team_members(organization)
-      end
       render json: { response: 'Updated' }, status: 200
     else
       render json: { response: 'Bad request', errors: @user.errors.messages }, status: 400
@@ -54,5 +51,12 @@ class Api::V1::OrganizationsController < Api::V1::BaseController
 
   def update_params
     params.permit(:public_enabled, :default_team_id)
+  end
+
+  def update_organization_default_team_memberships
+    if organization.saved_change_to_attribute?(:default_team_id)
+      GithubOrgMembershipService.new(token: @github_session.token)
+                                .import_default_team_members(organization)
+    end
   end
 end

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -7,12 +7,12 @@ end
 #
 # Table name: organization_memberships
 #
-#  id                      :integer          not null, primary key
-#  github_user_id          :integer
-#  organization_id         :integer
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  default_team_membership :boolean          default(FALSE)
+#  id                        :integer          not null, primary key
+#  github_user_id            :integer
+#  organization_id           :integer
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  is_member_of_default_team :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -3,15 +3,17 @@ class OrganizationMembership < ApplicationRecord
   belongs_to :organization
 end
 
+
 # == Schema Information
 #
 # Table name: organization_memberships
 #
-#  id              :integer          not null, primary key
-#  github_user_id  :integer
-#  organization_id :integer
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
+#  id                      :integer          not null, primary key
+#  github_user_id          :integer
+#  organization_id         :integer
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#  default_team_membership :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -3,7 +3,6 @@ class OrganizationMembership < ApplicationRecord
   belongs_to :organization
 end
 
-
 # == Schema Information
 #
 # Table name: organization_memberships

--- a/app/services/github_org_membership_service.rb
+++ b/app/services/github_org_membership_service.rb
@@ -21,14 +21,13 @@ class GithubOrgMembershipService < PowerTypes::Service.new(:token)
   def import_default_team_members(org)
     all_memberships = OrganizationMembership.where(organization_id: org.id)
     all_memberships.each do |membership|
-      membership.update!(default_team_membership: false)
+      membership.update!(is_member_of_default_team: false)
     end
     default_team_members = client.team_members(org.default_team_id)
     default_team_members.each do |member|
       member_user = GithubUser.find_by(gh_id: member.id)
-      org_membership = OrganizationMembership.find_by(github_user_id: member_user&.id,
-                                                      organization_id: org.id)
-      org_membership&.update!(default_team_membership: true)
+      org_membership = all_memberships.find_by(github_user_id: member_user&.id)
+      org_membership&.update!(is_member_of_default_team: true)
     end
   end
 

--- a/app/services/github_org_membership_service.rb
+++ b/app/services/github_org_membership_service.rb
@@ -18,6 +18,20 @@ class GithubOrgMembershipService < PowerTypes::Service.new(:token)
     org.members.where(id: ids).destroy_all
   end
 
+  def import_default_team_members(org)
+    all_memberships = OrganizationMembership.where(organization_id: org.id)
+    all_memberships.each do |membership|
+      membership.update!(default_team_membership: false)
+    end
+    default_team_members = client.team_members(org.default_team_id)
+    default_team_members.each do |member|
+      member_user = GithubUser.find_by(gh_id: member.id)
+      org_membership = OrganizationMembership.find_by(github_user_id: member_user&.id,
+                                                      organization_id: org.id)
+      org_membership&.update!(default_team_membership: true)
+    end
+  end
+
   private
 
   def github_org_members(org)

--- a/db/migrate/20190502193942_add_default_team_membership_to_organization_memberships.rb
+++ b/db/migrate/20190502193942_add_default_team_membership_to_organization_memberships.rb
@@ -1,5 +1,5 @@
 class AddDefaultTeamMembershipToOrganizationMemberships < ActiveRecord::Migration[5.1]
   def change
-    add_column :organization_memberships, :default_team_membership, :boolean, default: false
+    add_column :organization_memberships, :is_member_of_default_team, :boolean, default: false
   end
 end

--- a/db/migrate/20190502193942_add_default_team_membership_to_organization_memberships.rb
+++ b/db/migrate/20190502193942_add_default_team_membership_to_organization_memberships.rb
@@ -1,0 +1,5 @@
+class AddDefaultTeamMembershipToOrganizationMemberships < ActiveRecord::Migration[5.1]
+  def change
+    add_column :organization_memberships, :default_team_membership, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190412203725) do
+ActiveRecord::Schema.define(version: 20190502193942) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,6 +79,7 @@ ActiveRecord::Schema.define(version: 20190412203725) do
     t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "default_team_membership", default: false
     t.index ["github_user_id"], name: "index_organization_memberships_on_github_user_id"
     t.index ["organization_id"], name: "index_organization_memberships_on_organization_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 20190502193942) do
     t.bigint "organization_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "default_team_membership", default: false
+    t.boolean "is_member_of_default_team", default: false
     t.index ["github_user_id"], name: "index_organization_memberships_on_github_user_id"
     t.index ["organization_id"], name: "index_organization_memberships_on_organization_id"
   end

--- a/spec/services/github_org_membership_service_spec.rb
+++ b/spec/services/github_org_membership_service_spec.rb
@@ -148,8 +148,6 @@ describe GithubOrgMembershipService do
 
     let!(:gh_user) { double(id: user.gh_id) }
 
-    let!(:gh_user_2) { double(id: user2.gh_id) }
-
     context 'when empty team is selected as default' do
       before do
         allow(client).to receive(:team_members).with(organization.default_team_id).and_return([])


### PR DESCRIPTION
Se agrega la columna `default_team_membership`, con valor booleano, a la tabla `organization_membership`, para poder guardar en la base de datos cuáles miembros de la organización pertenecen al equipo seleccionado como default.
Cuando el admin selecciona un nuevo equipo default, se resetean todos los valores de `default_team_membership` de las membresías de la organización a `false`, y luego se actualizan a `true` las de los miembros que pertenezcan al equipo seleccionado. 