### PR TITLE
feat(admin): show user organizations

### DIFF
--- a/app/admin/github_user.rb
+++ b/app/admin/github_user.rb
@@ -38,7 +38,7 @@ ActiveAdmin.register GithubUser do
         panel "User Organizations" do
           table_for user.organization_memberships do
             column :id
-            column (:name) { |membership| Organization.find(membership.organization_id).login }
+            column (:name) { |membership| membership.organization.login }
             column :is_member_of_default_team
           end
         end

--- a/app/admin/github_user.rb
+++ b/app/admin/github_user.rb
@@ -19,6 +19,33 @@ ActiveAdmin.register GithubUser do
     actions
   end
 
+  show do |user|
+    columns do
+      column do
+        attributes_table do
+          row :avatar_url
+          row :email
+          row :gh_id
+          row :html_url
+          row :login
+          row :name
+          row :created_at
+          row :updated_at
+        end
+      end
+
+      column do
+        panel "User Organizations" do
+          table_for user.organization_memberships do
+            column :id
+            column (:name) { |membership| Organization.find(membership.organization_id).login }
+            column :is_member_of_default_team
+          end
+        end
+      end
+    end
+  end
+
   form do |f|
     f.inputs do
       f.input :name


### PR DESCRIPTION
Se agrega una tabla con las organizaciones del usuario, que incluye un flag que indica si el usuario pertenece o no al equipo default de esa organización.
![userOrganizations](https://user-images.githubusercontent.com/26115490/57401096-edd04200-71a2-11e9-9622-441d926d9e32.PNG)
