### PR TITLE
Membership webhook

### DIFF
--- a/app/commands/create_organization.rb
+++ b/app/commands/create_organization.rb
@@ -1,0 +1,28 @@
+class CreateOrganization < PowerTypes::Command.new(:token, :github_organization)
+  def perform
+    return if organization_exists?
+
+    organization = Organization.create!(
+      gh_id: @github_organization[:id],
+      login: @github_organization[:login]
+    )
+
+    trigger_sync_for organization
+    set_webhook_to organization
+  end
+
+  private
+
+  def organization_exists?
+    !Organization.find_by(gh_id: @github_organization[:id]).nil?
+  end
+
+  def trigger_sync_for(organization)
+    organization_sync = OrganizationSync.create!(organization: organization)
+    OrganizationSyncJob.perform_later(organization_sync, @token)
+  end
+
+  def set_webhook_to(organization)
+    Github::OrganizationWebhookService.new(token: @token, organization: organization).set
+  end
+end

--- a/app/commands/github/process_membership_event.rb
+++ b/app/commands/github/process_membership_event.rb
@@ -1,5 +1,38 @@
-class Github::ProcessMembershipEvent < PowerTypes::Command.new(event_payload)
+class Github::ProcessMembershipEvent < PowerTypes::Command.new(:event_payload)
   def perform
+    data = @event_payload.is_a?(Hash) ? RecursiveOpenStruct.new(@event_payload) : @event_payload
+    read_payload(data)
+    if event_action_is_added? && event_team_is_default_team?
+      @organization_membership.update!(is_member_of_default_team: true)
+    end
 
+    if event_action_is_removed? && event_team_is_default_team?
+      @organization_membership.update!(is_member_of_default_team: false)
+    end
+  end
+
+  private
+
+  def read_payload(data)
+    @event_action = data.action
+    @organization = Organization.find_by(gh_id: data.organization.id)
+    @user = GithubUser.find_by(gh_id: data.member.id)
+    @github_team_id = data.team.id
+    @organization_membership = OrganizationMembership.find_by(
+      github_user_id: @user.id,
+      organization_id: @organization.id
+    )
+  end
+
+  def event_action_is_added?
+    @event_action === "added"
+  end
+
+  def event_action_is_removed?
+    @event_action === "removed"
+  end
+
+  def event_team_is_default_team?
+    @github_team_id === @organization.default_team_id
   end
 end

--- a/app/commands/github/process_membership_event.rb
+++ b/app/commands/github/process_membership_event.rb
@@ -1,0 +1,5 @@
+class Github::ProcessMembershipEvent < PowerTypes::Command.new(event_payload)
+  def perform
+
+  end
+end

--- a/app/commands/process_webhook_event.rb
+++ b/app/commands/process_webhook_event.rb
@@ -4,6 +4,8 @@ class ProcessWebhookEvent < PowerTypes::Command.new(request: nil, event: nil)
       GithubPullRequestService.new(token: nil).handle_webhook_event(@request)
     elsif @event == 'pull_request_review'
       GithubPullRequestReviewService.new(token: nil).handle_webhook_event(@request)
+    elseif @event == 'membership'
+      Github::ProcessMembershipEvent.for(event_paylod: @request)
     end
   end
 end

--- a/app/commands/process_webhook_event.rb
+++ b/app/commands/process_webhook_event.rb
@@ -4,8 +4,8 @@ class ProcessWebhookEvent < PowerTypes::Command.new(request: nil, event: nil)
       GithubPullRequestService.new(token: nil).handle_webhook_event(@request)
     elsif @event == 'pull_request_review'
       GithubPullRequestReviewService.new(token: nil).handle_webhook_event(@request)
-    elseif @event == 'membership'
-      Github::ProcessMembershipEvent.for(event_paylod: @request)
+    elsif @event == 'membership'
+      Github::ProcessMembershipEvent.for(event_payload: @request)
     end
   end
 end

--- a/app/commands/process_webhook_event.rb
+++ b/app/commands/process_webhook_event.rb
@@ -1,10 +1,11 @@
 class ProcessWebhookEvent < PowerTypes::Command.new(request: nil, event: nil)
   def perform
-    if @event == 'pull_request'
+    case @event
+    when 'pull_request'
       GithubPullRequestService.new(token: nil).handle_webhook_event(@request)
-    elsif @event == 'pull_request_review'
+    when 'pull_request_review'
       GithubPullRequestReviewService.new(token: nil).handle_webhook_event(@request)
-    elsif @event == 'membership'
+    when 'membership'
       Github::ProcessMembershipEvent.for(event_payload: @request)
     end
   end

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -4,10 +4,15 @@ class Api::V1::OrganizationsController < Api::V1::BaseController
   after_action :update_organization_default_team_memberships, only: [:update]
 
   def sync
+    Github::OrganizationWebhookService.new(
+      token: @github_session.token,
+      organization: organization
+    ).set
     OrganizationSyncJob.perform_later(
       OrganizationSync.find_or_create_by(organization: organization),
       @github_session.token
     )
+
     respond_with organization, status: 202
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -20,16 +20,7 @@ class OrganizationsController < ApplicationController
   end
 
   def create
-    if @organization.nil?
-      organization = Organization.create!(
-        gh_id: @github_organization[:id],
-        login: @github_organization[:login]
-      )
-
-      OrganizationSyncJob.perform_later(OrganizationSync.create!(organization: organization),
-        @github_session.token)
-    end
-
+    CreateOrganization.for(token: @github_session.token, github_organization: @github_organization)
     redirect_to settings_organization_path(name: @github_organization[:login])
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -28,9 +28,11 @@ class OrganizationsController < ApplicationController
 
   def settings
     @is_admin_github_session = github_session.session[:client_type] == "admin"
-    load_behaviour_matrix_params
-    if @default_team_members_ids
-      set_behaviour_matrix
+    if @has_dashboard
+      load_behaviour_matrix_params
+      if @default_team_members_ids
+        set_behaviour_matrix
+      end
     end
   end
 

--- a/app/services/github/organization_webhook_service.rb
+++ b/app/services/github/organization_webhook_service.rb
@@ -1,0 +1,28 @@
+class Github::OrganizationWebhookService < PowerTypes::Service.new(:organization, :token)
+  def set
+    client.create_org_hook(@organization.login, hook_config, hook_options)
+    true
+  rescue Octokit::UnprocessableEntity => e
+    false
+  end
+
+  private
+
+  def hook_config
+    {
+      url: "#{ENV['APPLICATION_HOST']}/github_events",
+      content_type: 'json'
+    }
+  end
+
+  def hook_options
+    {
+      events: ["membership"],
+      active: true
+    }
+  end
+
+  def client
+    @client ||= BuildOctokitClient.for(token: @token)
+  end
+end

--- a/app/services/github/organization_webhook_service.rb
+++ b/app/services/github/organization_webhook_service.rb
@@ -2,7 +2,7 @@ class Github::OrganizationWebhookService < PowerTypes::Service.new(:organization
   def set
     client.create_org_hook(@organization.login, hook_config, hook_options)
     true
-  rescue Octokit::UnprocessableEntity => e
+  rescue Octokit::UnprocessableEntity
     false
   end
 
@@ -11,7 +11,8 @@ class Github::OrganizationWebhookService < PowerTypes::Service.new(:organization
   def hook_config
     {
       url: "#{ENV['APPLICATION_HOST']}/github_events",
-      content_type: 'json'
+      content_type: 'json',
+      secret: ENV['GH_HOOK_SECRET']
     }
   end
 

--- a/spec/commands/create_organization_spec.rb
+++ b/spec/commands/create_organization_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe CreateOrganization do
+  let(:token) { "token" }
+  let(:github_organization) { { id: 123, login: "Platanus" } }
+  let(:organization) { Organization.find_by(gh_id: 123) }
+
+  let(:github_organization_webhook_service) { double("github_organization_webhook_service") }
+
+  def perform
+    described_class.for(token: token, github_organization: github_organization)
+  end
+
+  context "when organization does not exist" do
+    before do
+      expect(OrganizationSyncJob).to receive(:perform_later)
+        .with(instance_of(OrganizationSync), token)
+
+      expect(Github::OrganizationWebhookService).to receive(:new)
+        .with(token: token, organization: instance_of(Organization))
+        .and_return(github_organization_webhook_service)
+
+      expect(github_organization_webhook_service).to receive(:set)
+    end
+
+    it { expect { perform }.to change { Organization.count }.by(1) }
+    it { expect { perform }.to change { OrganizationSync.count }.by(1) }
+
+    it "creates the correct Organization and OrganizationSync" do
+      perform
+
+      expect(Organization.last).to have_attributes(gh_id: 123, login: "Platanus")
+      expect(OrganizationSync.last.organization.id).to eq(organization.id)
+    end
+  end
+
+  context "when organization exists" do
+    before do
+      create(:organization, gh_id: 123, login: "Platanus")
+    end
+
+    it { expect { perform }.to change { Organization.count }.by(0) }
+    it { expect { perform }.to change { OrganizationSync.count }.by(0) }
+  end
+end

--- a/spec/commands/github/process_membership_event_spec.rb
+++ b/spec/commands/github/process_membership_event_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe Github::ProcessMembershipEvent do
+  def perform
+    described_class.for(event_payload: event_payload)
+  end
+
+  let!(:user) { create(:github_user, gh_id: 1) }
+  let!(:organization) { create(:organization, gh_id: 234, default_team_id: 123) }
+  let(:event_payload) do
+    double(
+      action: action,
+      member: double(id: 1),
+      team: double(id: 123),
+      organization: double(id: 234)
+    )
+  end
+
+  context 'when user is added to default team in Github' do
+    let!(:organization_membership) do
+      create(
+        :organization_membership,
+        github_user: user,
+        organization: organization,
+        is_member_of_default_team: false
+      )
+    end
+    let(:action) { 'added' }
+
+    it 'user is added to default team in local DB' do
+      perform
+      expect(OrganizationMembership.last.is_member_of_default_team).to be(true)
+    end
+  end
+
+  context 'when user is removed from default team in Github' do
+    let!(:organization_membership) do
+      create(
+        :organization_membership,
+        github_user: user,
+        organization: organization,
+        is_member_of_default_team: true
+      )
+    end
+    let(:action) { 'removed' }
+
+    it 'user is removed from default team in local DB' do
+      perform
+      expect(OrganizationMembership.last.is_member_of_default_team).to be(false)
+    end
+  end
+end

--- a/spec/commands/github/process_membership_event_spec.rb
+++ b/spec/commands/github/process_membership_event_spec.rb
@@ -28,8 +28,8 @@ describe Github::ProcessMembershipEvent do
     let(:action) { 'added' }
 
     it 'user is added to default team in local DB' do
-      perform
-      expect(OrganizationMembership.last.is_member_of_default_team).to be(true)
+      expect { perform }.to change { organization_membership.reload.is_member_of_default_team }
+        .from(false).to(true)
     end
   end
 
@@ -45,8 +45,8 @@ describe Github::ProcessMembershipEvent do
     let(:action) { 'removed' }
 
     it 'user is removed from default team in local DB' do
-      perform
-      expect(OrganizationMembership.last.is_member_of_default_team).to be(false)
+      expect { perform }.to change { organization_membership.reload.is_member_of_default_team }
+        .from(true).to(false)
     end
   end
 end

--- a/spec/commands/process_webhook_event_spec.rb
+++ b/spec/commands/process_webhook_event_spec.rb
@@ -32,7 +32,7 @@ describe ProcessWebhookEvent do
     let!(:request) { {} }
 
     it 'calls process membership event' do
-      expect_any_instance_of(Github::ProcessMembershipEvent).to receive(:perform)
+      expect(Github::ProcessMembershipEvent).to receive(:for).with(event_payload: request)
       perform(request, event)
     end
   end

--- a/spec/commands/process_webhook_event_spec.rb
+++ b/spec/commands/process_webhook_event_spec.rb
@@ -26,4 +26,14 @@ describe ProcessWebhookEvent do
       perform(request, event)
     end
   end
+
+  context 'membership event' do
+    let!(:event) { 'membership' }
+    let!(:request) { {} }
+
+    it 'calls process membership event' do
+      expect_any_instance_of(Github::ProcessMembershipEvent).to receive(:perform)
+      perform(request, event)
+    end
+  end
 end

--- a/spec/services/github/organization_webhook_service_spec.rb
+++ b/spec/services/github/organization_webhook_service_spec.rb
@@ -5,7 +5,13 @@ describe Github::OrganizationWebhookService do
   let(:organization) { create(:organization, login: "Platanus") }
 
   let(:client) { double(:client, pull_requests: true) }
-  let(:webook_config) { { url: "#{ENV['APPLICATION_HOST']}/github_events", content_type: 'json' } }
+  let(:webook_config) do
+    {
+      url: "#{ENV['APPLICATION_HOST']}/github_events",
+      content_type: 'json',
+      secret: ENV['GH_HOOK_SECRET']
+    }
+  end
   let(:webook_options) { { events: ["membership"], active: true } }
   let(:webhook_create_response) { double(:webhook_create_response) }
 
@@ -39,7 +45,7 @@ describe Github::OrganizationWebhookService do
                                                   .and_raise(Octokit::UnprocessableEntity)
       end
 
-      it 'creates the webhook' do
+      it 'does not create the webhook' do
         expect(service.set).to eq(false)
       end
     end

--- a/spec/services/github/organization_webhook_service_spec.rb
+++ b/spec/services/github/organization_webhook_service_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe Github::OrganizationWebhookService do
+  let(:token) { "token" }
+  let(:organization) { create(:organization, login: "Platanus") }
+
+  let(:client) { double(:client, pull_requests: true) }
+  let(:webook_config) { { url: "#{ENV['APPLICATION_HOST']}/github_events", content_type: 'json' } }
+  let(:webook_options) { { events: ["membership"], active: true } }
+  let(:webhook_create_response) { double(:webhook_create_response) }
+
+  def build(*_args)
+    described_class.new(*_args)
+  end
+
+  def service
+    build(token: token, organization: organization)
+  end
+
+  before do
+    allow(BuildOctokitClient).to receive(:for).with(token: token).and_return(client)
+  end
+
+  describe "#set" do
+    context "when webhook does not exist" do
+      before do
+        allow(client).to receive(:create_org_hook).with("Platanus", webook_config, webook_options)
+                                                  .and_return(webhook_create_response)
+      end
+
+      it 'creates the webhook' do
+        expect(service.set).to eq(true)
+      end
+    end
+
+    context "when webhook exists" do
+      before do
+        allow(client).to receive(:create_org_hook).with("Platanus", webook_config, webook_options)
+                                                  .and_raise(Octokit::UnprocessableEntity)
+      end
+
+      it 'creates the webhook' do
+        expect(service.set).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/services/github/organization_webhook_service_spec.rb
+++ b/spec/services/github/organization_webhook_service_spec.rb
@@ -30,8 +30,8 @@ describe Github::OrganizationWebhookService do
   describe "#set" do
     context "when webhook does not exist" do
       before do
-        allow(client).to receive(:create_org_hook).with("Platanus", webook_config, webook_options)
-                                                  .and_return(webhook_create_response)
+        expect(client).to receive(:create_org_hook).with("Platanus", webook_config, webook_options)
+                                                   .and_return(webhook_create_response)
       end
 
       it 'creates the webhook' do
@@ -41,8 +41,8 @@ describe Github::OrganizationWebhookService do
 
     context "when webhook exists" do
       before do
-        allow(client).to receive(:create_org_hook).with("Platanus", webook_config, webook_options)
-                                                  .and_raise(Octokit::UnprocessableEntity)
+        expect(client).to receive(:create_org_hook).with("Platanus", webook_config, webook_options)
+                                                   .and_raise(Octokit::UnprocessableEntity)
       end
 
       it 'does not create the webhook' do


### PR DESCRIPTION
Se integra el uso de `organization_webhooks` de Github, creándolos al inicializar o actualizar (en este caso solo si el webhook de la organización actualizada no existe todavía) una aplicación en froggo. Este webhook permite a Github avisar cuando se elimina o agrega un miembro a un equipo de la organización.
Utilizando este webhook, se refleja en la base de datos de froggo cuando en Github se agrega o elimina un miembro de la organización al equipo seleccionado como default en froggo.