### PR TITLE
fix(organization-dashboard): fix user images sizes

### DIFF
--- a/app/views/organizations/_dashboard_table.html.erb
+++ b/app/views/organizations/_dashboard_table.html.erb
@@ -8,7 +8,7 @@
     <% else %>
       <div class="matrix-dashboard">
         <div>
-          <div class="matrix__user--head" id="sticky-corner"></div>
+          <div class="matrix__user-head" id="sticky-corner"></div>
           <% @corrmat.selected_users.each_with_index do |user, i| %>
             <div class="matrix__user">
               <%= render partial: 'ranked_user_avatar',
@@ -21,7 +21,7 @@
         <div class="matrix__values">
           <div class="matrix__head" id="sticky-head">
             <% @corrmat.selected_users.each_with_index do |user, i| %>
-              <div class="matrix__user--head">
+              <div class="matrix__user-head">
                 <div class="matrix__picture">
                   <%= render partial: 'ranked_user_avatar',
                     locals: { user: user,


### PR DESCRIPTION
Se arregla el tamaño de los usuarios
![correct sizes](https://user-images.githubusercontent.com/26115490/57556613-81417880-7345-11e9-8505-1285884949eb.PNG)
