### PR TITLE
Fix Bug: settings page doesn't crash when the organization has no default team selected

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -28,7 +28,7 @@ class OrganizationsController < ApplicationController
 
   def settings
     @is_admin_github_session = github_session.session[:client_type] == "admin"
-    if @has_dashboard
+    if @has_dashboard && !@organization.default_team_id.nil?
       load_behaviour_matrix_params
       if @default_team_members_ids
         set_behaviour_matrix

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -28,7 +28,7 @@ class OrganizationsController < ApplicationController
 
   def settings
     @is_admin_github_session = github_session.session[:client_type] == "admin"
-    if @has_dashboard && !@organization.default_team_id.nil?
+    if @has_dashboard && @organization.default_team_id.present?
       load_behaviour_matrix_params
       if @default_team_members_ids
         set_behaviour_matrix

--- a/app/views/organizations/_settings_content.html.erb
+++ b/app/views/organizations/_settings_content.html.erb
@@ -24,9 +24,15 @@
       <%= t('messages.settings.behaviour_title') %>
       <%= @github_organization[:login] %>
     </div>
-    <div>
-      <%= render "behaviour_dashboard" %>
-    </div>
+    <% if @organization.default_team_id.nil? %>
+      <div class="card-extended__body-subtitle">
+        <%= t('messages.settings.no_default_team') %>
+      </div>
+    <% else %>
+      <div>
+        <%= render "behaviour_dashboard" %>
+      </div>
+    <% end %>
     <div class="card-extended__body-title">
       <%= t('messages.settings.repository_title') %>
       <%= @github_organization[:login] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,7 @@ en:
       admin_users: Manage users
       default_team: Default team
       behaviour_title: Behaviour in
+      no_default_team: Select default team to check your statistics
     profile:
       no_name: No name
       no_teams: No teams

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -60,6 +60,7 @@ es-CL:
       repository_count: repositorios
       default_team: Equipo default
       behaviour_title: Comportamiento en
+      no_default_team: Selecciona un equipo default para ver tus estadísticas
     profile:
       teams_dropdown_hint: Ver recomendaciones para...
       no_name: Sin nombre


### PR DESCRIPTION
Había un bug al crear una organización nueva, que al no tener `default_team_id` causaba un error al intentar entrar a las settings de la organización. 
Se corrige el bug, manejando el caso en que una organización no tiene equipo default para que no se calculen los valores de las estadísticas de la organización y se le solicita al admin que seleccione un equipo.
![no default team](https://user-images.githubusercontent.com/26115490/57650460-dd500b00-7598-11e9-92f5-24dbf03eebf9.PNG)
