### PR TITLE
fix(recommendation-behaviour): fix organization id used to retrieve t…

### DIFF
--- a/app/services/github_pull_request_review_service.rb
+++ b/app/services/github_pull_request_review_service.rb
@@ -124,10 +124,7 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
   def other_team_members_id(owner_id, organization_id)
     OrganizationMembership.where(organization_id: organization_id,
                                  is_member_of_default_team: true)
-                          .map do |membership|
-      {
-        user_id: membership.github_user_id
-      }.reject { |user_id| user_id == owner_id }
-    end
+                          .pluck(:github_user_id)
+                          .reject { |user_id| user_id == owner_id }
   end
 end

--- a/app/services/github_pull_request_review_service.rb
+++ b/app/services/github_pull_request_review_service.rb
@@ -8,14 +8,14 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
   end
 
   def import_all_from_pull_request(pull_request)
-    organization_default_team_id = 0
+    organization_id = 0
     include_recommendation = false
     github_pull_request_reviews(pull_request).each do |github_pull_request_review|
       break unless pull_request.repository.tracked
 
       import_github_pull_request_review(pull_request,
         github_pull_request_review,
-        organization_default_team_id,
+        organization_id,
         include_recommendation)
     end
   end
@@ -26,24 +26,24 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
       pull_req = PullRequest.find_by(gh_id: data_object.pull_request.id)
       repo = Repository.find_by(gh_id: data_object.repository.id)
       organization = Organization.find(repo.organization_id)
-      organization_default_team_id = organization.default_team_id
+      organization_id = organization.id
       include_recommendation = true
       import_github_pull_request_review(pull_req,
         data_object.review,
-        organization_default_team_id,
+        organization_id,
         include_recommendation)
     end
   end
 
   def import_github_pull_request_review(pull_request,
     github_pr_review,
-    organization_dt_id,
+    organization_id,
     include_recommendation)
     return unless pull_request.repository.reload.tracked
 
     params = build_pull_request_review_params(pull_request,
       github_pr_review,
-      organization_dt_id,
+      organization_id,
       include_recommendation)
 
     if pr_review = PullRequestReview.find_by(gh_id: github_pr_review.id)
@@ -68,7 +68,7 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
 
   def build_pull_request_review_params(pull_request,
     github_pr_review,
-    organization_dt_id,
+    organization_id,
     include_recommendation)
     user = GithubUserService.new.find_or_create(github_pr_review.user)
 
@@ -79,7 +79,7 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
     if include_recommendation
       review_params[:recommendation_behaviour] = get_behaviour(pull_request,
         github_pr_review,
-        organization_dt_id)
+        organization_id)
     end
 
     review_params
@@ -95,11 +95,11 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
     @client ||= BuildOctokitClient.for(token: @token)
   end
 
-  def get_behaviour(pull_request, gh_pull_request_review, org_dt_id)
+  def get_behaviour(pull_request, gh_pull_request_review, org_id)
     reviewer = GithubUser.find_by(gh_id: gh_pull_request_review.user.id)
     pull_request.pull_request_review_requests.each do |request|
       if request.github_user_id === reviewer.id
-        recommendations = team_review_request_recommendations(pull_request.owner_id, org_dt_id)
+        recommendations = team_review_request_recommendations(pull_request.owner_id, org_id)
         best_recommendations_ids = recommendations[:best].map { |user| user[:gh_id] }
         worst_recommendations_ids = recommendations[:worst].map { |user| user[:gh_id] }
         if best_recommendations_ids.include?(gh_pull_request_review.user.id)
@@ -114,15 +114,15 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
     :not_defined
   end
 
-  def team_review_request_recommendations(owner_id, organization_dt_id)
+  def team_review_request_recommendations(owner_id, organization_id)
     GetReviewRecommendations.for(
       github_user_id: owner_id,
-      other_users_ids: other_team_members_id(owner_id, organization_dt_id)
+      other_users_ids: other_team_members_id(owner_id, organization_id)
     )
   end
 
-  def other_team_members_id(owner_id, organization_dt_id)
-    OrganizationMembership.where(organization_id: organization_dt_id,
+  def other_team_members_id(owner_id, organization_id)
+    OrganizationMembership.where(organization_id: organization_id,
                                  is_member_of_default_team: true)
                           .map do |membership|
       {

--- a/spec/services/github_pull_request_review_service_spec.rb
+++ b/spec/services/github_pull_request_review_service_spec.rb
@@ -273,7 +273,7 @@ describe GithubPullRequestReviewService do
       expect(service).to receive(:import_github_pull_request_review)
         .with(pull_request,
           github_review_response,
-          organization.default_team_id,
+          organization.id,
           include_recommendation)
         .and_return(nil)
       service.handle_webhook_event(event_request_data)


### PR DESCRIPTION
…eam members ids
Se corrigen dos errores al revisar el comportamiento de un usuario al enviar un PR, frente a sus recomendaciones de froggo.
- Se estaba usando el `default_team_id` de la organización, en vez de su `id`, para determinar los miembros del equipo para calcular las recomendaciones.
- Los ids de los miembros del equipo se estaban pasando como hashes, en vez del `id` del usuario solamente, que es lo que se necesita para calcular las recomendaciones.
Con esto, se consigue que el comportamiento de un usuario se catalogue como `obedient`, `rebel` o `indifferent` según corresponda (antes se estaban registrando todos como `indifferent`).

![rebelsub](https://user-images.githubusercontent.com/26115490/57864909-afeaa380-77ca-11e9-88d6-4fb6bd90f5da.jpg)
