### PR TITLE
feat(slack-integration): recommend next PR by Slack

### DIFF
--- a/app/commands/get_recommendations.rb
+++ b/app/commands/get_recommendations.rb
@@ -1,0 +1,24 @@
+class GetRecommendations < PowerTypes::Command.new(:github_user, :organization)
+  def perform
+    if membership&.is_member_of_default_team
+      GetReviewRecommendations.for(
+        github_user_id: @github_user.id,
+        other_users_ids: other_default_team_members_id
+      )
+    end
+  end
+
+  private
+
+  def membership
+    @membership ||= OrganizationMembership.find_by(github_user_id: @github_user.id,
+                                                   organization_id: @organization.id)
+  end
+
+  def other_default_team_members_id
+    OrganizationMembership
+      .where(organization_id: @organization.id, is_member_of_default_team: true)
+      .pluck(:github_user_id)
+      .reject { |id| id == @github_user.id }
+  end
+end

--- a/app/commands/get_recommendations.rb
+++ b/app/commands/get_recommendations.rb
@@ -20,5 +20,6 @@ class GetRecommendations < PowerTypes::Command.new(:github_user, :organization)
       .where(organization_id: @organization.id, is_member_of_default_team: true)
       .pluck(:github_user_id)
       .reject { |id| id == @github_user.id }
+      .sort
   end
 end

--- a/app/controllers/api/v1/github_users_controller.rb
+++ b/app/controllers/api/v1/github_users_controller.rb
@@ -56,6 +56,7 @@ class Api::V1::GithubUsersController < Api::V1::BaseController
       .where(gh_id: team_members_gh_ids)
       .pluck(:id)
       .reject { |id| id == github_user.id }
+      .sort
   end
 
   def organization

--- a/app/controllers/slack/commands_controller.rb
+++ b/app/controllers/slack/commands_controller.rb
@@ -1,0 +1,18 @@
+class Slack::CommandsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  before_action :verify_slack_token
+
+  def create
+    render json: { text: commands_service.reply }, status: :ok
+  end
+
+  private
+
+  def commands_service
+    @commands_service ||= SlackCommandsService.new(params: params)
+  end
+
+  def verify_slack_token
+    return render json: {}, status: :forbidden unless ENV['SLACK_API_TOKEN'] == params['token']
+  end
+end

--- a/app/controllers/slack/events_controller.rb
+++ b/app/controllers/slack/events_controller.rb
@@ -1,0 +1,20 @@
+class Slack::EventsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    handle_event(JSON.parse(request.body.read))
+  end
+
+  private
+
+  def handle_event(data)
+    case data['type']
+    when 'url_verification'
+      respond_slack_verification_challenge(data)
+    end
+  end
+
+  def respond_slack_verification_challenge(data)
+    render json: { challenge: data['challenge'] }, status: :ok
+  end
+end

--- a/app/services/slack_commands_service.rb
+++ b/app/services/slack_commands_service.rb
@@ -1,0 +1,58 @@
+class SlackCommandsService < PowerTypes::Service.new(:params)
+  COMMAND_RESPONSES = {
+    '/froggo' => :reply_hello,
+    '/next_pr' => :reply_next_pr_recommendation
+  }
+
+  def reply
+    send(COMMAND_RESPONSES[command])
+  end
+
+  private
+
+  def reply_hello
+    I18n.t('messages.slack.hello')
+  end
+
+  def reply_next_pr_recommendation
+    return I18n.t('messages.slack.wrong_params') if wrong_params?
+
+    I18n.t('messages.slack.recommended_users', users: recommended_users.join(', '))
+  end
+
+  def command
+    @params['command']
+  end
+
+  def github_user_name
+    @params['text'].split(' ').first
+  end
+
+  def organization_name
+    @params['text'].split(' ').second
+  end
+
+  def github_user
+    @github_user ||= GithubUser.find_by(login: github_user_name)
+  end
+
+  def organization
+    @organization ||= Organization.find_by(login: organization_name)
+  end
+
+  def recommended_users
+    recommendations = GetRecommendations.for(github_user: github_user,
+                                             organization: organization)
+    recommendations[:best].pluck(:login)
+  end
+
+  def wrong_params?
+    organization_name.nil? || organization.nil? || github_user.nil?
+  end
+
+  def user_not_authorized?
+    membership = OrganizationMembership.find_by(github_user_id: github_user.id,
+                                                organization_id: organization.id)
+    membership.nil? || !membership.is_member_of_default_team
+  end
+end

--- a/app/services/slack_commands_service.rb
+++ b/app/services/slack_commands_service.rb
@@ -16,6 +16,7 @@ class SlackCommandsService < PowerTypes::Service.new(:params)
 
   def reply_next_pr_recommendation
     return I18n.t('messages.slack.wrong_params') if wrong_params?
+    return I18n.t('messages.slack.no_recommendations') if user_not_authorized?
 
     I18n.t('messages.slack.recommended_users', users: recommended_users.join(', '))
   end
@@ -53,6 +54,6 @@ class SlackCommandsService < PowerTypes::Service.new(:params)
   def user_not_authorized?
     membership = OrganizationMembership.find_by(github_user_id: github_user.id,
                                                 organization_id: organization.id)
-    membership.nil? || !membership.is_member_of_default_team
+    !membership&.is_member_of_default_team
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,7 @@ en:
     slack:
       hello: croak!
       recommended_users: Send your next PR to %{users}
+      no_recommendations: "Ups, you don't belong to that organization or it's default team :frog:"
       wrong_params: Croak! I don't understand... remember to write something like `/next_pr bunzli platanus`
     profile:
       no_name: No name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,10 @@ en:
       default_team: Default team
       behaviour_title: Behaviour in
       no_default_team: Select default team to check your statistics
+    slack:
+      hello: croak!
+      recommended_users: Send your next PR to %{users}
+      wrong_params: Croak! I don't understand... remember to write something like `/next_pr bunzli platanus`
     profile:
       no_name: No name
       no_teams: No teams

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -61,6 +61,10 @@ es-CL:
       default_team: Equipo default
       behaviour_title: Comportamiento en
       no_default_team: Selecciona un equipo default para ver tus estadísticas
+    slack:
+      hello: croak!
+      recommended_users: Asigna tu próximo PR a %{users}
+      wrong_params: Croak! No entendí... recuerda poner algo como `/next_pr bunzli platanus`
     profile:
       teams_dropdown_hint: Ver recomendaciones para...
       no_name: Sin nombre

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -64,6 +64,7 @@ es-CL:
     slack:
       hello: croak!
       recommended_users: Asigna tu próximo PR a %{users}
+      no_recommendations: "Ups, no perteneces a esa organización o a su team default :frog:"
       wrong_params: Croak! No entendí... recuerda poner algo como `/next_pr bunzli platanus`
     profile:
       teams_dropdown_hint: Ver recomendaciones para...

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,11 @@ Rails.application.routes.draw do
   resources :users, only: [:show], controller: 'github_users'
   get 'me' => 'github_users#me'
 
+  scope path: '/slack', module: 'slack' do
+    resources :commands, only: [:create]
+    resources :events, only: [:create]
+  end
+
   scope path: '/api', defaults: { format: 'json' } do
     api_version(module: "Api::V1", header: { name: "Accept", value: "version=1" }, default: true) do
       resources :repositories, only: [:update]

--- a/spec/commands/get_recommendations_spec.rb
+++ b/spec/commands/get_recommendations_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe GetRecommendations do
+  def perform(*_args)
+    described_class.for(*_args)
+  end
+
+  let(:requesting_user) { create(:github_user) }
+  let(:organization) { create(:organization) }
+
+  context 'with user within the organization' do
+    let(:github_users_in_default_team) { create_list(:github_user, 3) }
+    let(:github_users_not_in_default_team) { create_list(:github_user, 3) }
+    let(:review_recommendations) { double(:review_recommendations) }
+
+    before do
+      create(:organization_membership, github_user_id: requesting_user.id,
+                                       organization_id: organization.id,
+                                       is_member_of_default_team: true)
+
+      github_users_in_default_team.each do |github_user|
+        create(:organization_membership, github_user_id: github_user.id,
+                                         organization_id: organization.id,
+                                         is_member_of_default_team: true)
+      end
+
+      github_users_not_in_default_team.each do |github_user|
+        create(:organization_membership, github_user_id: github_user.id,
+                                         organization_id: organization.id,
+                                         is_member_of_default_team: false)
+      end
+
+      allow(GetReviewRecommendations).to receive(:for)
+        .with(github_user_id: requesting_user.id,
+              other_users_ids: github_users_in_default_team.pluck(:id))
+        .and_return(review_recommendations)
+    end
+
+    it 'returns same recommendation as review recommendation' do
+      expect(perform(github_user: requesting_user, organization: organization))
+        .to eq(review_recommendations)
+    end
+  end
+
+  context 'with user not within the organization' do
+    it 'returns nil' do
+      expect(perform(github_user: requesting_user, organization: organization))
+        .to be_nil
+    end
+  end
+
+  context 'with user not in default team' do
+    before do
+      create(:organization_membership, github_user_id: requesting_user.id,
+                                       organization_id: organization.id,
+                                       is_member_of_default_team: false)
+    end
+
+    it 'returns nil' do
+      expect(perform(github_user: requesting_user, organization: organization))
+        .to be_nil
+    end
+  end
+end

--- a/spec/services/slack_commands_service_spec.rb
+++ b/spec/services/slack_commands_service_spec.rb
@@ -35,6 +35,10 @@ describe SlackCommandsService do
     allow(I18n).to receive(:t)
       .with('messages.slack.wrong_params')
       .and_return('Avíspate')
+
+    allow(I18n).to receive(:t)
+      .with('messages.slack.no_recommendations')
+      .and_return('No puedes ver esto')
   end
 
   context 'command is /froggo' do
@@ -73,10 +77,29 @@ describe SlackCommandsService do
     it { expect(service.reply).to eq('Avíspate') }
   end
 
-  context 'command is /next_pr and organization doesn\'t exist' do
+  context 'command is /next_pr and user doesn\'t exist' do
     let(:params) { { 'command' => '/next_pr', 'text' => 'billgates platanus' } }
 
     it { expect(service.reply).to eq('Avíspate') }
+  end
+
+  context 'command is /next_pr and user doesn\'t belong to default team' do
+    let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs platanus' } }
+
+    before do
+      create(:organization_membership, github_user_id: github_user.id,
+                                       organization_id: organization.id,
+                                       is_member_of_default_team: false)
+    end
+
+    it { expect(service.reply).to eq('No puedes ver esto') }
+  end
+
+  context 'command is /next_pr and user doesn\'t belong to organization' do
+    let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs budacom' } }
+    let(:organization) { create(:organization, login: 'budacom') }
+
+    it { expect(service.reply).to eq('No puedes ver esto') }
   end
 
   context 'command is /next_pr and user doesn\'t belong to default team' do

--- a/spec/services/slack_commands_service_spec.rb
+++ b/spec/services/slack_commands_service_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+describe SlackCommandsService do
+  def build(*_args)
+    described_class.new(*_args)
+  end
+
+  let(:service) { build(params: params) }
+  let(:github_user) { create(:github_user, login: 'isidoravs') }
+  let(:organization) { create(:organization, login: 'platanus') }
+  let(:recommendations) do
+    {
+      best: [
+        create(:github_user, login: 'blackjid'),
+        create(:github_user, login: 'gmq'),
+        create(:github_user, login: 'iobaixas')
+      ]
+    }
+  end
+
+  before do
+    allow(GetRecommendations).to receive(:for)
+      .with(github_user: github_user,
+            organization: organization)
+      .and_return(recommendations)
+
+    allow(I18n).to receive(:t)
+      .with('messages.slack.recommended_users', users: 'blackjid, gmq, iobaixas')
+      .and_return('Asigna tu próximo PR a blackjid, gmq, iobaixas')
+
+    allow(I18n).to receive(:t)
+      .with('messages.slack.hello')
+      .and_return('croak!')
+
+    allow(I18n).to receive(:t)
+      .with('messages.slack.wrong_params')
+      .and_return('Avíspate')
+  end
+
+  context 'command is /froggo' do
+    let(:params) { { 'command' => '/froggo' } }
+
+    it { expect(service.reply).to eq('croak!') }
+  end
+
+  context 'command is /next_pr and params are correct' do
+    let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs platanus' } }
+
+    before do
+      create(:organization_membership, github_user_id: github_user.id,
+                                       organization_id: organization.id,
+                                       is_member_of_default_team: true)
+    end
+
+    it { expect(service.reply).to eq('Asigna tu próximo PR a blackjid, gmq, iobaixas') }
+  end
+
+  context 'command is /next_pr and there\'s no organization' do
+    let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs' } }
+
+    it { expect(service.reply).to eq('Avíspate') }
+  end
+
+  context 'command is /next_pr and there\'s no content' do
+    let(:params) { { 'command' => '/next_pr', 'text' => '' } }
+
+    it { expect(service.reply).to eq('Avíspate') }
+  end
+
+  context 'command is /next_pr and organization doesn\'t exist' do
+    let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs bananus' } }
+
+    it { expect(service.reply).to eq('Avíspate') }
+  end
+
+  context 'command is /next_pr and organization doesn\'t exist' do
+    let(:params) { { 'command' => '/next_pr', 'text' => 'billgates platanus' } }
+
+    it { expect(service.reply).to eq('Avíspate') }
+  end
+
+  context 'command is /next_pr and user doesn\'t belong to default team' do
+    let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs platanus' } }
+
+    before do
+      create(:organization_membership, github_user_id: github_user.id,
+                                       organization_id: organization.id,
+                                       is_member_of_default_team: false)
+    end
+
+    it { expect(service.reply).to eq('No puedes ver esto') }
+  end
+
+  context 'command is /next_pr and user doesn\'t belong to organization' do
+    let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs budacom' } }
+    let(:organization) { create(:organization, login: 'budacom') }
+
+    it { expect(service.reply).to eq('No puedes ver esto') }
+  end
+end


### PR DESCRIPTION
Se recomienda por Slack a quienes asignar su próximo PR, a través del slash command `next_pr <gihub_username> <organization_name>`. 

1) Se crea el comando `GetRecommendations` que por ahora funciona como un wrapper del comando `GetReviewRecommendations`. La diferencia es que recibe el usario y la organización, en vez del `id` del usario y el `id` de todos los demás usuarios con los que se quiere comparar; y entrega las recomandaciones según el team default de la organización. La idea es que el nuevo comando reemplace al antiguo más adelante. 

2) Para que las recomendaciones sean las mismas en la aplicación y en slack, se le deben pasar los ids de usuarios ordenados a `GetReviewRecomendations` para manejar los casos de empate.

3) Se crea un servicio `SlackCommands` que maneja las respuestas que se entregan al usuario. Los slash commands manejados hasta ahora son `/froggo` y `/next_pr`. 
Se revisan los casos de error en que:
- usuario u organización no existen
- usuario no pertenence a la organización o su team default
- número de parámetros adicionales a slash command es incorrecto

4) Se crean los controladores que reciben el payload enviado por Slack (POST) y envía respuesta entregada por `SlackCommandsService`.
