### PR TITLE
Feat/new organization access

### DIFF
--- a/app/controllers/github_auth_controller.rb
+++ b/app/controllers/github_auth_controller.rb
@@ -13,10 +13,17 @@ class GithubAuthController < ApplicationController
                                      callback_params: { gh_org: permitted_params[:gh_org] })
   end
 
+  def organization_authenticate!
+    redirect_to GetGithubAuthUrl.for(callback_action: :add_organization, client_type: :member)
+  end
+
   def callback
     set_session_gh_access
     if permitted_params[:callback_action] == 'settings'
       redirect_to settings_organization_path(name: permitted_params[:gh_org])
+    elsif permitted_params[:callback_action] == 'add_organization'
+      delete_application_grant
+      authenticate!
     else
       redirect_to user_path(github_user) || organizations_path
     end
@@ -32,5 +39,13 @@ class GithubAuthController < ApplicationController
     session_code = request.query_parameters['code']
     result = Octokit.exchange_code_for_token(session_code, ENV['GH_AUTH_ID'], ENV['GH_AUTH_SECRET'])
     github_session.set_session(result[:access_token], permitted_params[:client_type])
+  end
+
+  def delete_application_grant
+    Octokit.client_id = ENV['GH_AUTH_ID']
+    Octokit.client_secret = ENV['GH_AUTH_SECRET']
+    Octokit.client.as_app do |client|
+      client.delete "/applications/#{ENV['GH_AUTH_ID']}/grants/#{github_session.token}"
+    end
   end
 end

--- a/app/views/github_users/_profile_card.html.erb
+++ b/app/views/github_users/_profile_card.html.erb
@@ -13,6 +13,13 @@
           <% end %>
         </div>
       </div>
+      <% if @github_session.user.id === @github_user.id %>
+        <div class="card-extended__dashboard-button">
+          <%= link_to t('messages.profile.give_permissions'),
+            org_authenticate_path,
+            class: "button button--big"%>
+        </div>
+      <% end %>
       <div class="profile-teams">
         <div class="profile-teams__hint">
           <%= t('messages.profile.teams_dropdown_hint') %>

--- a/app/views/github_users/_profile_card.html.erb
+++ b/app/views/github_users/_profile_card.html.erb
@@ -13,13 +13,6 @@
           <% end %>
         </div>
       </div>
-      <% if @github_session.user.id === @github_user.id %>
-        <div class="card-extended__dashboard-button">
-          <%= link_to t('messages.profile.give_permissions'),
-            org_authenticate_path,
-            class: "button button--big"%>
-        </div>
-      <% end %>
       <div class="profile-teams">
         <div class="profile-teams__hint">
           <%= t('messages.profile.teams_dropdown_hint') %>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -9,6 +9,11 @@
           <img class="user-menu__image" slot="btn" src="<%= @github_session.user.avatar_url %>"/>
           <div class="user-menu__body" slot="body">
             <%= link_to t('messages.header.close_session'), close_session_path, class: 'user-menu__option'%>
+            <% if @github_session.user.id === @github_user.id %>
+              <%= link_to t('messages.profile.give_permissions'),
+                  org_authenticate_path,
+                  class: 'user-menu__option'%>
+            <% end %>
           </div>
         </dropdown>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,3 +103,4 @@ en:
       recommended_reviewers: We recommend you request a review from one of these persons
       not_recommended_reviewers: Avoid requesting reviews from these persons
       no_recommendations: You don't belong to any organization so there are no recommendations for you
+      give_permissions: Give permissions for new organization

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,4 +103,4 @@ en:
       recommended_reviewers: We recommend you request a review from one of these persons
       not_recommended_reviewers: Avoid requesting reviews from these persons
       no_recommendations: You don't belong to any organization so there are no recommendations for you
-      give_permissions: Give permissions for new organization
+      give_permissions: Configure organizations

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -75,4 +75,4 @@ es-CL:
       recommended_reviewers: Te recomendamos mandar tu próximo PR a alguna de estas personas
       not_recommended_reviewers: Evita mandarle otro PR a estas personas
       no_recommendations: No tenemos recomendaciones para ti dado que no perteneces a ninguna organización
-      give_permissions: Otorgar permisos para nueva organización
+      give_permissions: Configurar organizaciones

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -75,3 +75,4 @@ es-CL:
       recommended_reviewers: Te recomendamos mandar tu próximo PR a alguna de estas personas
       not_recommended_reviewers: Evita mandarle otro PR a estas personas
       no_recommendations: No tenemos recomendaciones para ti dado que no perteneces a ninguna organización
+      give_permissions: Otorgar permisos para nueva organización

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get 'oauth' => 'github_auth#oauth_request', as: :close_session
   get 'oauth_to_gh' => 'github_auth#authenticate!', as: :github_authenticate
   get 'admin_oauth_to_gh' => 'github_auth#admin_authenticate!', as: :admin_authenticate
+  get 'org_oauth_to_gh' => 'github_auth#organization_authenticate!', as: :org_authenticate
   post 'github_events' => 'webhook#receive'
 
   root 'home#index'

--- a/spec/controllers/github_auth_controller_spec.rb
+++ b/spec/controllers/github_auth_controller_spec.rb
@@ -55,14 +55,26 @@ RSpec.describe GithubAuthController, type: :controller do
       it { expect(response).to redirect_to(settings_organization_path(name: gh_org)) }
     end
 
-    context 'from home modify organizations' do
-      before do
-        get :callback, params: { client_type: :member,
-                                 code: github_return_code,
-                                 callback_action: 'add_organization' }
+    context 'configure organizations' do
+      context 'from home' do
+        before do
+          get :callback, params: { client_type: :member,
+                                   code: github_return_code,
+                                   callback_action: 'add_organization' }
+        end
+
+        it { expect(response).to redirect_to(user_path(github_session.user)) }
       end
 
-      it { expect(response).to redirect_to(user_path(github_session.user)) }
+      context 'when grant is not revoked' do
+        before do
+          allow(subject).to receive(:delete_application_grant).and_return(false)
+        end
+        it 'does not redirect to github auth' do
+          subject.organization_authenticate!
+          expect { expect(GetGithubAuthUrl).to_not receive(:for) }
+        end
+      end
     end
   end
 end

--- a/spec/controllers/github_auth_controller_spec.rb
+++ b/spec/controllers/github_auth_controller_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe GithubAuthController, type: :controller do
         name: 'name',
         set_session: [],
         froggo_path: path,
-        user: 1
+        user: 1,
+        token: 'token'
       )
     end
 
@@ -52,6 +53,16 @@ RSpec.describe GithubAuthController, type: :controller do
       end
 
       it { expect(response).to redirect_to(settings_organization_path(name: gh_org)) }
+    end
+
+    context 'from home modify organizations' do
+      before do
+        get :callback, params: { client_type: :member,
+                                 code: github_return_code,
+                                 callback_action: 'add_organization' }
+      end
+
+      it { expect(response).to redirect_to(user_path(github_session.user)) }
     end
   end
 end


### PR DESCRIPTION
Antes para agregar una nueva organización a froggo, era necesario revocar los permisos de la aplicación manualmente en GitHub, para que froggo volviera a pedirlos y se pudiera seleccionar la organización a la que se quiere dar permiso.
Se agrega un botón en el perfil del usuario que permite agregar una organización sin tener que revocar los permisos manualmente en GitHub.
Esto se realiza mediante la API de Github, que permite, después de realizar una [Basic Authentication](https://developer.github.com/v3/oauth_authorizations/#revoke-an-authorization-for-an-application) de la aplicación, revocar el permiso para un usuario.
![neworg](https://user-images.githubusercontent.com/26115490/57884382-7af44600-77f6-11e9-860b-163be4a6a2f6.gif)
