### PR TITLE
feat(slack): send summary of user statistics with /summary command

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,9 +92,11 @@ en:
       no_default_team: Select default team to check your statistics
     slack:
       hello: croak!
+      summary: "Your scores: \n %{obedient_count} followed recommendations | %{indifferent_count} ignored recommendations | %{rebel_count} not followed recommendations"
       recommended_users: Send your next PR to %{users}
       no_recommendations: "Ups, you don't belong to that organization or it's default team :frog:"
-      wrong_params: Croak! I don't understand... remember to write something like `/next_pr bunzli platanus`
+      next_pr_wrong_params: Croak! I don't understand... remember to write something like `/next_pr bunzli platanus`
+      summary_wrong_params: Croak! I don't understand... remember to write something like `/summary bunzli platanus`
     profile:
       no_name: No name
       no_teams: No teams

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -63,9 +63,11 @@ es-CL:
       no_default_team: Selecciona un equipo default para ver tus estadísticas
     slack:
       hello: croak!
+      summary: "Tus puntajes son: \n %{obedient_count} recomendaciones seguidas | %{indifferent_count} recomendaciones ignoradas | %{rebel_count} recomendaciones no seguidas"
       recommended_users: Asigna tu próximo PR a %{users}
       no_recommendations: "Ups, no perteneces a esa organización o a su team default :frog:"
-      wrong_params: Croak! No entendí... recuerda poner algo como `/next_pr bunzli platanus`
+      next_pr_wrong_params: Croak! No entendí... recuerda poner algo como `/next_pr bunzli platanus`
+      summary_wrong_params: Croak! No entendí... recuerda poner algo como `/summary bunzli platanus`
     profile:
       teams_dropdown_hint: Ver recomendaciones para...
       no_name: Sin nombre

--- a/spec/services/slack_commands_service_spec.rb
+++ b/spec/services/slack_commands_service_spec.rb
@@ -65,7 +65,7 @@ describe SlackCommandsService do
   context 'command is /next_pr and params are correct' do
     let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs platanus' } }
 
-    before do
+    let!(:membership) do
       create(:organization_membership, github_user_id: github_user.id,
                                        organization_id: organization.id,
                                        is_member_of_default_team: true)
@@ -101,7 +101,7 @@ describe SlackCommandsService do
   context 'command is /next_pr and user doesn\'t belong to default team' do
     let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs platanus' } }
 
-    before do
+    let!(:membership) do
       create(:organization_membership, github_user_id: github_user.id,
                                        organization_id: organization.id,
                                        is_member_of_default_team: false)

--- a/spec/services/slack_commands_service_spec.rb
+++ b/spec/services/slack_commands_service_spec.rb
@@ -17,12 +17,19 @@ describe SlackCommandsService do
       ]
     }
   end
+  let(:statistics) { { obedient: 1, indifferent: 0, rebel: 2 } }
+  let(:statistics_count) { { obedient_count: 1, indifferent_count: 0, rebel_count: 2 } }
 
   before do
     allow(GetRecommendations).to receive(:for)
       .with(github_user: github_user,
             organization: organization)
       .and_return(recommendations)
+
+    allow(ComputeUserStatistics).to receive(:for)
+      .with(github_user_id: github_user.id,
+            organization_id: organization.id)
+      .and_return(statistics)
 
     allow(I18n).to receive(:t)
       .with('messages.slack.recommended_users', users: 'blackjid, gmq, iobaixas')
@@ -33,12 +40,20 @@ describe SlackCommandsService do
       .and_return('croak!')
 
     allow(I18n).to receive(:t)
-      .with('messages.slack.wrong_params')
+      .with('messages.slack.next_pr_wrong_params')
       .and_return('Avíspate')
 
     allow(I18n).to receive(:t)
       .with('messages.slack.no_recommendations')
       .and_return('No puedes ver esto')
+
+    allow(I18n).to receive(:t)
+      .with('messages.slack.summary', **statistics_count)
+      .and_return('Puntos: 1 obediencia, 0 indiferencia, 2 rebeldía')
+
+    allow(I18n).to receive(:t)
+      .with('messages.slack.summary_wrong_params')
+      .and_return('Avíspate')
   end
 
   context 'command is /froggo' do
@@ -102,10 +117,44 @@ describe SlackCommandsService do
     it { expect(service.reply).to eq('No puedes ver esto') }
   end
 
-  context 'command is /next_pr and user doesn\'t belong to default team' do
-    let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs platanus' } }
+  context 'command is /summary and params are correct' do
+    let(:params) { { 'command' => '/summary', 'text' => 'isidoravs platanus' } }
+    let!(:membership) do
+      create(:organization_membership, github_user_id: github_user.id,
+                                       organization_id: organization.id,
+                                       is_member_of_default_team: true)
+    end
 
-    before do
+    it { expect(service.reply).to eq('Puntos: 1 obediencia, 0 indiferencia, 2 rebeldía') }
+  end
+
+  context 'command is /summary and there\'s no organization' do
+    let(:params) { { 'command' => '/summary', 'text' => 'isidoravs' } }
+
+    it { expect(service.reply).to eq('Avíspate') }
+  end
+
+  context 'command is /summary and there\'s no content' do
+    let(:params) { { 'command' => '/summary', 'text' => '' } }
+
+    it { expect(service.reply).to eq('Avíspate') }
+  end
+
+  context 'command is /summary and organization doesn\'t exist' do
+    let(:params) { { 'command' => '/summary', 'text' => 'isidoravs bananus' } }
+
+    it { expect(service.reply).to eq('Avíspate') }
+  end
+
+  context 'command is /summary and user doesn\'t exist' do
+    let(:params) { { 'command' => '/summary', 'text' => 'billgates platanus' } }
+
+    it { expect(service.reply).to eq('Avíspate') }
+  end
+
+  context 'command is /summary and user doesn\'t belong to default team' do
+    let(:params) { { 'command' => '/summary', 'text' => 'isidoravs platanus' } }
+    let!(:membership) do
       create(:organization_membership, github_user_id: github_user.id,
                                        organization_id: organization.id,
                                        is_member_of_default_team: false)
@@ -114,8 +163,8 @@ describe SlackCommandsService do
     it { expect(service.reply).to eq('No puedes ver esto') }
   end
 
-  context 'command is /next_pr and user doesn\'t belong to organization' do
-    let(:params) { { 'command' => '/next_pr', 'text' => 'isidoravs budacom' } }
+  context 'command is /summary and user doesn\'t belong to organization' do
+    let(:params) { { 'command' => '/summary', 'text' => 'isidoravs budacom' } }
     let(:organization) { create(:organization, login: 'budacom') }
 
     it { expect(service.reply).to eq('No puedes ver esto') }


### PR DESCRIPTION
Se agrega el manejo de un nuevo comando `/summary` que retorna las estadísticas de obediencia del usuario.

Además se cambia `messages.slack.wrong_params` por `messages.slack.next_pr_wrong_params` para diferenciar el caso en que los parámetros son incorrectos para el slash command `/next_pr` y `/summary`.

**Tests**
1. Se revisan los casos de error en que:
- número de parámetros adicionales a slash command es incorrecto
- usuario u organización no existen
- usuario no pertenence a la organización o su team default
2. Se cambia el uso de `before do` por `let!` para `:organization_membership`
