### PR TITLE
Fix/repos syncronization

### DIFF
--- a/app/models/organization_sync.rb
+++ b/app/models/organization_sync.rb
@@ -11,6 +11,7 @@ class OrganizationSync < ApplicationRecord
     event :execute, after: Proc.new { update(start_time: DateTime.current) } do
       transitions from: :created, to: :executing
       transitions from: :completed, to: :executing
+      transitions from: :failed, to: :executing
     end
 
     event :fail, after: Proc.new { update(end_time: DateTime.current) } do

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -8,7 +8,7 @@ class PullRequest < ApplicationRecord
   has_many :pull_request_reviews, dependent: :destroy
   has_many :pull_request_reviewers, through: :pull_request_reviews, source: :github_user
 
-  has_many :pull_request_relations
+  has_many :pull_request_relations, dependent: :destroy
   has_many :pull_request_review_requests, dependent: :destroy
 
   scope :within_month_limit, -> do

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -6,7 +6,7 @@ class Repository < ApplicationRecord
 
   has_many :pull_requests, dependent: :destroy
   has_many :pull_request_reviews, through: :pull_requests
-  has_many :hooks, as: :resource, dependent: :destroy
+  has_many :hooks, as: :resource, dependent: :destroy, inverse_of: :resource
 
   validates :gh_id, presence: true
   validates :full_name, presence: true

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -4,9 +4,9 @@ class Repository < ApplicationRecord
 
   belongs_to :organization
 
-  has_many :pull_requests
+  has_many :pull_requests, dependent: :destroy
   has_many :pull_request_reviews, through: :pull_requests
-  has_many :hooks, as: :resource
+  has_many :hooks, as: :resource, dependent: :destroy
 
   validates :gh_id, presence: true
   validates :full_name, presence: true

--- a/app/services/github_repository_service.rb
+++ b/app/services/github_repository_service.rb
@@ -34,7 +34,10 @@ class GithubRepositoryService < PowerTypes::Service.new(:token)
   end
 
   def remove_old_repositories(organization, current_repos)
-    organization.repositories.where.not(gh_id: current_repos.map { |e| e[:id] }).each(&:destroy!)
+    organization.repositories.where.not(gh_id: current_repos.map { |e| e[:id] }).each do |repo|
+      remove_webhook(repo)
+      repo.destroy
+    end
   end
 
   private

--- a/app/services/github_repository_service.rb
+++ b/app/services/github_repository_service.rb
@@ -36,7 +36,7 @@ class GithubRepositoryService < PowerTypes::Service.new(:token)
   def remove_old_repositories(organization, current_repos)
     organization.repositories.where.not(gh_id: current_repos.map { |e| e[:id] }).each do |repo|
       remove_webhook(repo)
-      repo.destroy
+      repo.destroy!
     end
   end
 

--- a/spec/models/organization_sync_spec.rb
+++ b/spec/models/organization_sync_spec.rb
@@ -10,28 +10,28 @@ RSpec.describe OrganizationSync, type: :model do
   describe 'aasm' do
     context '#execute' do
       it '#execute changes state from created to executing' do
-        expect { sync.execute }.to change(sync, :state).from('created').to('executing')
+        expect { sync.execute }.to change{ sync.state }.from('created').to('executing')
       end
 
-      context '#when execute completed' do
+      context 'when execute completed' do
         before do
           sync.execute
           sync.complete
         end
 
         it '#execute changes state from completed to executing' do
-          expect { sync.execute }.to change(sync, :state).from('completed').to('executing')
+          expect { sync.execute }.to change{ sync.state }.from('completed').to('executing')
         end
       end
 
-      context '#when execute failed' do
+      context 'when execute failed' do
         before do
           sync.execute
           sync.fail
         end
 
         it '#execute changes state from failed to executing' do
-          expect { sync.execute }.to change(sync, :state).from('failed').to('executing')
+          expect { sync.execute }.to change{ sync.state }.from('failed').to('executing')
         end
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe OrganizationSync, type: :model do
         sync.execute
       end
       it '#fail changes state from executing to failed' do
-        expect { sync.fail }.to change(sync, :state).from('executing').to('failed')
+        expect { sync.fail }.to change{ sync.state }.from('executing').to('failed')
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe OrganizationSync, type: :model do
         sync.execute
       end
       it '#complete changes state from executing to completed' do
-        expect { sync.complete }.to change(sync, :state).from('executing').to('completed')
+        expect { sync.complete }.to change{ sync.state }.from('executing').to('completed')
       end
     end
   end

--- a/spec/models/organization_sync_spec.rb
+++ b/spec/models/organization_sync_spec.rb
@@ -10,6 +10,28 @@ RSpec.describe OrganizationSync, type: :model do
       it '#execute changes state from created to executing' do
         expect { subject.execute }.to change(subject, :state).from('created').to('executing')
       end
+
+      context '#execute completed' do
+        before do
+          subject.execute
+          subject.complete
+        end
+
+        it '#execute changes state from completed to executing' do
+          expect { subject.execute }.to change(subject, :state).from('completed').to('executing')
+        end
+      end
+
+      context '#execute failed' do
+        before do
+          subject.execute
+          subject.fail
+        end
+
+        it '#execute changes state from failed to executing' do
+          expect { subject.execute }.to change(subject, :state).from('failed').to('executing')
+        end
+      end
     end
 
     context '#fail' do

--- a/spec/models/organization_sync_spec.rb
+++ b/spec/models/organization_sync_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe OrganizationSync, type: :model do
+  subject(:sync) { described_class.new }
+
   describe 'relationships' do
     it { should belong_to(:organization) }
   end
@@ -8,47 +10,47 @@ RSpec.describe OrganizationSync, type: :model do
   describe 'aasm' do
     context '#execute' do
       it '#execute changes state from created to executing' do
-        expect { subject.execute }.to change(subject, :state).from('created').to('executing')
+        expect { sync.execute }.to change(sync, :state).from('created').to('executing')
       end
 
-      context '#execute completed' do
+      context '#when execute completed' do
         before do
-          subject.execute
-          subject.complete
+          sync.execute
+          sync.complete
         end
 
         it '#execute changes state from completed to executing' do
-          expect { subject.execute }.to change(subject, :state).from('completed').to('executing')
+          expect { sync.execute }.to change(sync, :state).from('completed').to('executing')
         end
       end
 
-      context '#execute failed' do
+      context '#when execute failed' do
         before do
-          subject.execute
-          subject.fail
+          sync.execute
+          sync.fail
         end
 
         it '#execute changes state from failed to executing' do
-          expect { subject.execute }.to change(subject, :state).from('failed').to('executing')
+          expect { sync.execute }.to change(sync, :state).from('failed').to('executing')
         end
       end
     end
 
     context '#fail' do
       before do
-        subject.execute
+        sync.execute
       end
       it '#fail changes state from executing to failed' do
-        expect { subject.fail }.to change(subject, :state).from('executing').to('failed')
+        expect { sync.fail }.to change(sync, :state).from('executing').to('failed')
       end
     end
 
     context '#complete' do
       before do
-        subject.execute
+        sync.execute
       end
       it '#complete changes state from executing to completed' do
-        expect { subject.complete }.to change(subject, :state).from('executing').to('completed')
+        expect { sync.complete }.to change(sync, :state).from('executing').to('completed')
       end
     end
   end

--- a/spec/models/organization_sync_spec.rb
+++ b/spec/models/organization_sync_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe OrganizationSync, type: :model do
   describe 'aasm' do
     context '#execute' do
       it '#execute changes state from created to executing' do
-        expect { sync.execute }.to change{ sync.state }.from('created').to('executing')
+        expect { sync.execute }.to change { sync.state }.from('created').to('executing')
       end
 
       context 'when execute completed' do
@@ -20,7 +20,7 @@ RSpec.describe OrganizationSync, type: :model do
         end
 
         it '#execute changes state from completed to executing' do
-          expect { sync.execute }.to change{ sync.state }.from('completed').to('executing')
+          expect { sync.execute }.to change { sync.state }.from('completed').to('executing')
         end
       end
 
@@ -31,7 +31,7 @@ RSpec.describe OrganizationSync, type: :model do
         end
 
         it '#execute changes state from failed to executing' do
-          expect { sync.execute }.to change{ sync.state }.from('failed').to('executing')
+          expect { sync.execute }.to change { sync.state }.from('failed').to('executing')
         end
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe OrganizationSync, type: :model do
         sync.execute
       end
       it '#fail changes state from executing to failed' do
-        expect { sync.fail }.to change{ sync.state }.from('executing').to('failed')
+        expect { sync.fail }.to change { sync.state }.from('executing').to('failed')
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe OrganizationSync, type: :model do
         sync.execute
       end
       it '#complete changes state from executing to completed' do
-        expect { sync.complete }.to change{ sync.state }.from('executing').to('completed')
+        expect { sync.complete }.to change { sync.state }.from('executing').to('completed')
       end
     end
   end

--- a/spec/services/github_repository_service_spec.rb
+++ b/spec/services/github_repository_service_spec.rb
@@ -206,12 +206,12 @@ describe GithubRepositoryService do
     end
 
     context "when exists old repositories in db" do
-      let!(:org_repo) {
+      let!(:org_repo) do
         create(:repository, organization: organization, gh_id: 101, full_name: "Platanus labs")
-      }
-      let!(:not_org_repo) {
+      end
+      let!(:not_org_repo) do
         create(:repository, organization: organization, gh_id: 105, full_name: "I don't exist")
-      }
+      end
 
       before do
         allow(service).to receive(:remove_webhook)

--- a/spec/services/github_repository_service_spec.rb
+++ b/spec/services/github_repository_service_spec.rb
@@ -180,13 +180,14 @@ describe GithubRepositoryService do
         }
       ]
     end
+    let(:service) { build(token: token) }
 
     before do
       allow(client).to receive(:org_repos).with(organization.login).and_return(github_repositories)
     end
 
     def run_method
-      build(token: token).import_all_from_organization(organization)
+      service.import_all_from_organization(organization)
       organization.repositories.reload
     end
 
@@ -205,11 +206,22 @@ describe GithubRepositoryService do
     end
 
     context "when exists old repositories in db" do
+      let!(:org_repo) { create(:repository, organization: organization, gh_id: 101, full_name: "Platanus labs") }
+      let!(:not_org_repo) { create(:repository, organization: organization, gh_id: 105, full_name: "I don't exist") }
+
       before do
-        create(:repository, organization: organization, gh_id: 101, full_name: "Platanus labs")
-        create(:repository, organization: organization, gh_id: 105, full_name: "I don't exist")
+        allow(service).to receive(:remove_webhook)
       end
+
       it { expect { run_method }.to change { organization.repositories.count }.by(-1) }
+      it do
+        run_method
+        expect(service).to have_received(:remove_webhook).with(not_org_repo).once
+      end
+      it do
+        run_method
+        expect(service).not_to have_received(:remove_webhook).with(org_repo)
+      end
     end
   end
 end

--- a/spec/services/github_repository_service_spec.rb
+++ b/spec/services/github_repository_service_spec.rb
@@ -206,8 +206,12 @@ describe GithubRepositoryService do
     end
 
     context "when exists old repositories in db" do
-      let!(:org_repo) { create(:repository, organization: organization, gh_id: 101, full_name: "Platanus labs") }
-      let!(:not_org_repo) { create(:repository, organization: organization, gh_id: 105, full_name: "I don't exist") }
+      let!(:org_repo) {
+        create(:repository, organization: organization, gh_id: 101, full_name: "Platanus labs")
+      }
+      let!(:not_org_repo) {
+        create(:repository, organization: organization, gh_id: 105, full_name: "I don't exist")
+      }
 
       before do
         allow(service).to receive(:remove_webhook)


### PR DESCRIPTION
* Se agrega dependencia on destroy al modelo Repository, para los modelos PullRequest y Hooks
* Se agrega la transición de failed a executing para el modelo OrganizationSync (OrganizationSyncJob no tiene problema si falla y se vuelve a ejecutar)
* Se desactivan los webhook antes de borrar los repositorios antiguos
* Se implementan tests para probar que se llama a remove_webhook cuando se eliminan los repos antiguos
* Se implementan tests para verificar que OrganizationSync pueda pasar de completed/failed a executing