### PR TITLE
fix(github_service): fixed user names not being stored.

### DIFF
--- a/app/services/github_user_service.rb
+++ b/app/services/github_user_service.rb
@@ -1,11 +1,13 @@
 class GithubUserService < PowerTypes::Service.new
   def find_or_create(github_user_params)
-    GithubUser.create_with(
+    found = GithubUser.create_with(
       login: github_user_params.login,
       avatar_url: github_user_params.avatar_url,
       html_url: github_user_params.html_url,
       email: github_user_params.email,
       name: github_user_params.name
     ).find_or_create_by!(gh_id: github_user_params.id)
+    found.update!(name: github_user_params.name) if found.name.nil?
+    found
   end
 end

--- a/spec/services/github_user_service_spec.rb
+++ b/spec/services/github_user_service_spec.rb
@@ -17,7 +17,16 @@ describe GithubUserService do
            avatar_url: '',
            html_url: '',
            email: '',
-           name: '')
+           name: nil)
+  end
+
+  let (:user3) do
+    double(login: 'a user',
+           id: gh_user.gh_id,
+           avatar_url: '',
+           html_url: '',
+           email: '',
+           name: 'jaime')
   end
 
   def build(*_args)
@@ -33,6 +42,12 @@ describe GithubUserService do
     it 'find an existing user in BD' do
       find = build.find_or_create(user2)
       expect(find).to eq(gh_user)
+    end
+
+    it 'updates name of existing user' do
+      gh_user.update(name: nil)
+      find = build.find_or_create(user3)
+      expect(find.name).to eq(user3.name)
     end
   end
 end


### PR DESCRIPTION
Arreglado que cuando los usuarios eran creados antes de que se logearan a froggo por primera vez
(ej: cuando aparecen en un PR), quedaban permanentemente sin nombre en la BD.

Ahora los nombres se irán guardando a medida que los usuarios se vayan logeando.
