### PR TITLE
Fix/sidekiq bug

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -23,3 +23,7 @@ DB_HOST=127.0.0.1
 DB_PORT=$(make services-port SERVICE=postgresql PORT=5432)
 DB_USER=postgres
 DB_POOL=25
+
+# Redis
+REDIS_HOST=127.0.0.1
+REDIS_PORT=$(make services-port SERVICE=redis PORT=6379)

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,7 +24,7 @@ rack_env = ENV.fetch("RACK_ENV", "development")
 environment rack_env
 
 # Set 1 day timeout for workers while developing
-worker_timeout 1.day.seconds.to_i if rack_env == "development"
+worker_timeout 24 * 60 * 60 if rack_env == "development"
 
 on_worker_boot do
   # Worker specific setup for Rails 4.1+

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,7 +7,7 @@ production:
 :limits:
     pull_requests: <%= ENV.fetch('SIDEKIQ_PULL_REQS_CONCURRENCY', 1) %>
     reviews: <%= ENV.fetch('SIDEKIQ_REVIEWS_CONCURRENCY', 4) %>
-:schedule:
+# :schedule:
   #  an_scheduled_task:
   #    cron: '0 * * * * *'  # Runs once per minute
   #    class: ExampleJob


### PR DESCRIPTION
Al parecer el tener el `:schedule` vacío en `config/sidekiq.yml` hace que se caiga sidekiq al inicio. Como no hay jobs calendarizados simplemente se comenta esa linea.

Además se actualiza `config/puma.rb` con [este fix](https://github.com/platanus/potassium/pull/313) y se especifica el host y port de Redis para que corra en local.