### PR TITLE
Froggo teams form

### DIFF
--- a/app/assets/stylesheets/app/app.scss
+++ b/app/assets/stylesheets/app/app.scss
@@ -10,6 +10,7 @@
 @import './profile';
 @import './repository';
 @import './public_dashboard';
+@import './froggo_teams';
 @import './colored_number.scss';
 
 *,

--- a/app/assets/stylesheets/app/froggo_teams.scss
+++ b/app/assets/stylesheets/app/froggo_teams.scss
@@ -1,3 +1,81 @@
+.froggo-teams {
+  padding: 40px;
+}
+.froggo-teams-list {
+  padding: 40px;
+
+  &__section {
+    margin-top: 4%;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: $black;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    text-decoration: none;
+    font-family: $main-font;
+    font-size: 20px;
+    font-weight: 900;
+  }
+}
+
 .froggo-teams-form {
   display: flex;
+}
+
+.froggo-teams-from-organization {
+  flex-direction: column;
+  display: flex;
+  margin-right: 0;
+
+  &__organization {
+    border: 3px solid $primary-border;
+    margin-top: 4px;
+    margin-bottom: 4px;
+  }
+
+  &__organization-bar {
+    display: flex;
+    background: $primary-shadow-color;
+    color: $white;
+    font-size: 20px;
+    font-weight: 900;
+    height: 30px;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px;
+    font-family: $main-font;
+  }
+
+  &__organization-title {
+    display: flex;
+  }
+
+  &__organization-create-button {
+    display: flex;
+  }
+
+  &__organization-teams {
+    padding: 10px;
+    color: $primary;
+    font-family: $roboto-condensed;
+    font-size: 18px;
+  }
+
+  &__organization-team {
+    display: flex;
+    padding: 10px;
+    margin-left: 4px;
+    border: 2px solid $primary-border;
+    width: max-content;
+    height: 22px;
+    align-items: center;
+    color: $primary;
+    font-family: $roboto-condensed;
+    font-size: 16px;
+    cursor: pointer;
+  }
 }

--- a/app/assets/stylesheets/app/froggo_teams.scss
+++ b/app/assets/stylesheets/app/froggo_teams.scss
@@ -1,6 +1,7 @@
 .froggo-teams {
   padding: 40px;
 }
+
 .froggo-teams-list {
   padding: 40px;
 
@@ -77,5 +78,58 @@
     font-family: $roboto-condensed;
     font-size: 16px;
     cursor: pointer;
+  }
+}
+
+.froggo-teams-show {
+  flex-direction: column;
+  display: flex;
+  margin-right: 0;
+
+  &__name {
+    font-size: 22px;
+    font-weight: 900;
+    color: $secondary-color;
+  }
+
+  &__members {
+    margin: 30px 0;
+  }
+
+  &__member-title {
+    margin: 30px 0;
+  }
+
+  &__member {
+    display: flex;
+    align-items: center;
+    color: $primary;
+    text-decoration: none;
+    margin-bottom: 15px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__picture {
+    width: 35px;
+    height: 35px;
+    margin-right: 10px;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  &__username {
+    display: flex;
+    align-items: center;
+    color: $light-primary;
+    margin-top: 5px;
+    text-decoration: none;
+
+    svg {
+      fill: $light-primary;
+      margin-right: 5px;
+    }
   }
 }

--- a/app/assets/stylesheets/app/header.scss
+++ b/app/assets/stylesheets/app/header.scss
@@ -7,12 +7,24 @@
   &__container {
     height: 100%;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
   }
 
   &__logo-container {
     display: flex;
     align-items: center;
+    margin-right: auto;
+  }
+
+  &__teams-button-container {
+    display: flex;
+    align-items: center;
+    font-family: 'Arial Rounded MT Bold';
+    font-weight: 700;
+    font-size: 15px;
+    color: $white;
+    text-decoration: none;
+    padding: 20px;
   }
 
   &__logo {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,4 +15,3 @@
  */
 @import './pl-dropdown.scss';
 @import './app/app.scss';
-@import './app/froggo_teams.scss';

--- a/app/controllers/froggo_teams_controller.rb
+++ b/app/controllers/froggo_teams_controller.rb
@@ -1,12 +1,21 @@
 class FroggoTeamsController < ApplicationController
+  before_action :authenticate_github_user
   def new
     @organization = Organization.find(params[:organization_id])
     @users = @organization.members
+    @github_user = github_user
   end
 
   def index
     user = GithubUser.find(params[:github_user_id])
     @user_teams = user.froggo_teams
     @organizations = user.organizations
+    @github_user = github_user
+  end
+
+  def show
+    @froggo_team = FroggoTeam.find(params[:id])
+    @froggo_team_members = @froggo_team.github_users
+    @github_user = github_user
   end
 end

--- a/app/controllers/froggo_teams_controller.rb
+++ b/app/controllers/froggo_teams_controller.rb
@@ -3,4 +3,10 @@ class FroggoTeamsController < ApplicationController
     @organization = Organization.find(params[:organization_id])
     @users = @organization.members
   end
+
+  def index
+    user = GithubUser.find(params[:github_user_id])
+    @user_teams = user.froggo_teams
+    @organizations = user.organizations
+  end
 end

--- a/app/javascript/components/froggo-team-form.vue
+++ b/app/javascript/components/froggo-team-form.vue
@@ -21,8 +21,10 @@
 <script>
 import UsersDropdown from './users-dropdown';
 import { CREATE_NEW_FROGGO_TEAM } from '../store/action-types';
+import showMessageMixin from '../mixins/showMessageMixin';
 
 export default {
+  mixins: [showMessageMixin],
   data() {
     return {
       teamName: '',
@@ -47,8 +49,15 @@ export default {
       this.$store.dispatch(CREATE_NEW_FROGGO_TEAM, {
         name: this.teamName,
         organizationId: this.organization.id,
-        users: this.selected,
-      });
+        users: JSON.stringify(this.selected.map(user => user.id)),
+      })
+        .then(response => {
+          this.showMessage('se creó el grupo correctamente');
+          window.location.href = `/froggo_teams/${response.data.id}`;
+        })
+        .catch(() => {
+          this.showMessage('no se pudo crear el grupo');
+        });
     },
   },
   components: {

--- a/app/javascript/components/froggo-team-form.vue
+++ b/app/javascript/components/froggo-team-form.vue
@@ -49,7 +49,7 @@ export default {
       this.$store.dispatch(CREATE_NEW_FROGGO_TEAM, {
         name: this.teamName,
         organizationId: this.organization.id,
-        users: JSON.stringify(this.selected.map(user => user.id)),
+        userIds: this.selected.map(user => user.id),
       })
         .then(response => {
           this.showMessage('se creó el grupo correctamente');

--- a/app/javascript/components/froggo-team-show.vue
+++ b/app/javascript/components/froggo-team-show.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="froggo-teams-show">
+    <div class="froggo-teams-show__name">
+      {{ froggoTeam.name }}
+    </div>
+    <div class="froggo-teams-show__members">
+      <div class="froggo-teams-show__member-title">
+        Miembros:
+      </div>
+      <a
+        class="froggo-teams-show__member"
+        v-for="user in froggoTeamMembers"
+        :key="user.id"
+        :href="`/users/${user.id}`"
+      >
+        <img
+          class="froggo-teams-show__picture"
+          :src="user.avatar_url"
+        >
+        <div class="froggo-teams-show__username">
+          {{ user.login }}
+        </div>
+      </a>
+    </div>
+    <div>
+      <button @click="editFroggoTeam">
+        Editar Equipo
+      </button>
+      <button @click="deleteFroggoTeam">
+        Eliminar Equipo
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+
+export default {
+
+  props: {
+    userId: {
+      type: Number,
+      required: true,
+    },
+    froggoTeam: {
+      type: Object,
+      required: true,
+    },
+    froggoTeamMembers: {
+      type: Array,
+      required: true,
+    },
+  },
+  methods: {
+    editFroggoTeam() {
+      return;
+    },
+    deleteFroggoTeam() {
+      const response = confirm('Estás seguro de querer borrar el equipo ?');
+      if (response) {
+        axios.delete(`/api/froggo_teams/${this.froggoTeam.id}`)
+          .then(() => { window.location.href = `/github_users/${this.userId}/froggo_teams`; });
+      }
+    },
+  },
+};
+</script>
+

--- a/app/javascript/components/froggo-teams-list.vue
+++ b/app/javascript/components/froggo-teams-list.vue
@@ -1,0 +1,62 @@
+<template>
+  <div>
+    <div class="froggo-teams-from-organization">
+      <div
+        v-for="organization in organizations"
+        :key="organization.id"
+        class="froggo-teams-from-organization__organization"
+      >
+        <div class="froggo-teams-from-organization__organization-bar">
+          <div class="froggo-teams-from-organization__organization-title">
+            Organización:   {{ organization.login }}
+          </div>
+          <div class="froggo-teams-from-organization__organization-create-button">
+            <button @click="newFroggoTeam(organization.id)">
+              Crear Equipo
+            </button>
+          </div>
+        </div>
+        <div class="froggo-teams-from-organization__organization-teams">
+          Equipos a los que pertenezco:
+        </div>
+        <div
+          v-for="team in userTeams"
+          :key="team.id"
+        >
+          <a
+            :href="`/froggo_teams/${team.id}`"
+          >
+            <div
+              class="froggo-teams-from-organization__organization-team"
+              v-if="organization.id === team.organization_id"
+            >
+              {{ team.name }}
+            </div>
+          </a>
+        </div><br>
+      </div><br>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+
+  props: {
+    userTeams: {
+      type: Array,
+      required: true,
+    },
+    organizations: {
+      type: Array,
+      required: true,
+    },
+  },
+  methods: {
+    newFroggoTeam(organizationId) {
+      window.location.href = `/organizations/${organizationId}/froggo_teams/new`;
+    },
+  },
+};
+</script>

--- a/app/javascript/mixins/showMessageMixin.js
+++ b/app/javascript/mixins/showMessageMixin.js
@@ -1,0 +1,12 @@
+export default {
+  methods: {
+    showMessage(message) {
+      this.$toasted.show(message, {
+        theme: 'toasted-primary',
+        position: 'top-center',
+        duration: 7000,
+      });
+    },
+  },
+};
+

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ import Dropdown from '../components/pl-dropdown.vue';
 import TeamsDropdown from '../components/teams-dropdown.vue';
 import OrganizationsDropdown from '../components/organizations-dropdown.vue';
 import FroggoTeamForm from '../components/froggo-team-form.vue';
+import FroggoTeamsList from '../components/froggo-teams-list.vue';
 import TimespanDropdown from '../components/timespan-dropdown.vue';
 import Repository from '../components/repository.vue';
 import EnablePublicButton from '../components/enable-public-button.vue';
@@ -36,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
   Vue.component('teams-dropdown', TeamsDropdown);
   Vue.component('organizations-dropdown', OrganizationsDropdown);
   Vue.component('froggo-team-form', FroggoTeamForm);
+  Vue.component('froggo-teams-list', FroggoTeamsList);
   Vue.component('timespan-dropdown', TimespanDropdown);
   Vue.component('sync-organization-button', SyncOrganizationButton);
   Vue.component('dashboard-syncing-icon', DashboardSyncingIcon);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ import Dropdown from '../components/pl-dropdown.vue';
 import TeamsDropdown from '../components/teams-dropdown.vue';
 import OrganizationsDropdown from '../components/organizations-dropdown.vue';
 import FroggoTeamForm from '../components/froggo-team-form.vue';
+import FroggoTeamShow from '../components/froggo-team-show.vue';
 import FroggoTeamsList from '../components/froggo-teams-list.vue';
 import TimespanDropdown from '../components/timespan-dropdown.vue';
 import Repository from '../components/repository.vue';
@@ -37,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
   Vue.component('teams-dropdown', TeamsDropdown);
   Vue.component('organizations-dropdown', OrganizationsDropdown);
   Vue.component('froggo-team-form', FroggoTeamForm);
+  Vue.component('froggo-team-show', FroggoTeamShow);
   Vue.component('froggo-teams-list', FroggoTeamsList);
   Vue.component('timespan-dropdown', TimespanDropdown);
   Vue.component('sync-organization-button', SyncOrganizationButton);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -5,6 +5,7 @@ import Vue from 'vue/dist/vue.esm';
 import VueI18n from 'vue-i18n';
 import VTooltip from 'v-tooltip';
 import VueHorizontalList from 'vue-horizontal-list';
+import Toasted from 'vue-toasted';
 
 import Dropdown from '../components/pl-dropdown.vue';
 import TeamsDropdown from '../components/teams-dropdown.vue';
@@ -32,6 +33,14 @@ Vue.use(VueHorizontalList);
 
 /* eslint-disable max-statements */
 document.addEventListener('DOMContentLoaded', () => {
+  Vue.use(Toasted, {
+    action: {
+      icon: 'close',
+      onClick: (e, toastObject) => {
+        toastObject.goAway(0);
+      },
+    },
+  });
   Vue.component('repository', Repository);
   Vue.component('enable-public-button', EnablePublicButton);
   Vue.component('dropdown', Dropdown);

--- a/app/javascript/store/modules/froggo_team/actions.js
+++ b/app/javascript/store/modules/froggo_team/actions.js
@@ -1,29 +1,12 @@
 import axios from 'axios';
-import * as humps from 'humps';
-
+import { decamelizeKeys } from 'humps';
 import {
   CREATE_NEW_FROGGO_TEAM,
 } from '../../action-types';
 
 export default {
-  [CREATE_NEW_FROGGO_TEAM](_, { name, organizationId, users }) {
-    axios.post(
-      `/api/organizations/${organizationId}/froggo_teams`,
-      { name },
-      { headers: { 'Content-Type': 'application/json' } },
-    )
-      .then(async (response) => {
-        const { data: { id } } = response;
-
-        return Promise.all(users.map(user => axios.post(`/api/froggo_teams/${id}/add_member`,
-          humps.decamelizeKeys({ githubLogin: user.login }))));
-      })
-      .then((response) => {
-        alert('se creó el grupo correctamente');
-        window.location.href = `/froggo_teams/${response[0].data.id}`;
-      })
-      .catch(() => {
-        alert('no se pudo crear el grupo correctamente');
-      });
+  [CREATE_NEW_FROGGO_TEAM](_, { name, organizationId, userIds }) {
+    return axios.post(
+      `/api/organizations/${organizationId}/froggo_teams`, decamelizeKeys({ name, newMembersIds: userIds }));
   },
 };

--- a/app/javascript/store/modules/froggo_team/actions.js
+++ b/app/javascript/store/modules/froggo_team/actions.js
@@ -18,7 +18,12 @@ export default {
         return Promise.all(users.map(user => axios.post(`/api/froggo_teams/${id}/add_member`,
           humps.decamelizeKeys({ githubLogin: user.login }))));
       })
-      .then(() => alert('se creó el grupo correctamente'))
-      .catch(() => { alert('no se pudo crear el grupo correctamente'); });
+      .then((response) => {
+        alert('se creó el grupo correctamente');
+        window.location.href = `/froggo_teams/${response[0].data.id}`;
+      })
+      .catch(() => {
+        alert('no se pudo crear el grupo correctamente');
+      });
   },
 };

--- a/app/views/froggo_teams/_froggo_teams_list.html.erb
+++ b/app/views/froggo_teams/_froggo_teams_list.html.erb
@@ -1,0 +1,15 @@
+<div class="card">
+    <div class="froggo-teams">
+        <div class="froggo-teams-list">
+            <div class="froggo-teams-list__title">
+                <%= t('messages.header.teams') %>
+            </div>
+            <div class="froggo-teams-list__section">
+                <froggo-teams-list
+                    :user-teams="<%= @user_teams.to_json %>"
+                    :organizations="<%= @organizations.to_json %>"
+                />
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/views/froggo_teams/index.html.erb
+++ b/app/views/froggo_teams/index.html.erb
@@ -1,0 +1,6 @@
+<div id="app" class="app">
+  <%= render 'partials/header' %>
+  <div class="container">
+    <%= render 'froggo_teams_list' %>
+  </div>
+</div>

--- a/app/views/froggo_teams/show.html.erb
+++ b/app/views/froggo_teams/show.html.erb
@@ -1,0 +1,14 @@
+<div id="app" class="app">
+  <%= render 'partials/header' %>
+  <div class="container">
+    <div class="card">
+      <div class="froggo-teams">
+        <froggo-team-show
+          :user-id="<%= @github_user.id %>"
+          :froggo-team="<%= @froggo_team.to_json %>"
+          :froggo-team-members="<%= @froggo_team_members.to_json %>"
+        />
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -4,6 +4,7 @@
       <%= image_tag 'froggo-logo.svg', class: 'header__logo' %>
     <% end %>
     <% unless @github_user.nil? %>
+      <%= link_to t('messages.header.teams'), github_user_froggo_teams_path(github_user_id: @github_session.user.id), class: 'header__teams-button-container'%>
       <div class="header__menu-container">
         <dropdown class="user-menu header__user-menu">
           <img class="user-menu__image" slot="btn" src="<%= @github_session.user.avatar_url %>"/>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
     header:
       organizations: Organizations
       close_session: Close session
+      teams: Teams
     home:
       title: Code review tool for GitHub pull requests
       subtitle: Discover how your Github organization's code review and pull requests are distributed.

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -42,6 +42,7 @@ es-CL:
     header:
       organizations: Organizaciones
       close_session: Cerrar sesión
+      teams: Equipos
     home:
       title: Descubre cómo se distribuyen los Pull Requests en tu organización
       subtitle: Gran parte de la cultura en tu organización se trasmite por Pull Requests. ¡Asegúrate que todos reciban una buena parte!

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,6 @@ Rails.application.routes.draw do
       resources :organizations do
         resources :froggo_teams, only: [:index, :show, :create, :destroy, :update], shallow: true do
           member do
-            post 'add_member'
             post 'remove_member'
           end
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     resources :froggo_teams, only: [:index], controller: 'froggo_teams'
   end
 
+  resources :froggo_teams, only: [:show], controller: 'froggo_teams'
+
   scope path: '/api', defaults: { format: 'json' } do
     api_version(module: "Api::V1", header: { name: "Accept", value: "version=1" }, default: true) do
       resources :repositories, only: [:update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,10 @@ Rails.application.routes.draw do
     resources :froggo_teams, only: [:new], controller: 'froggo_teams'
   end
 
+  resources :github_users do
+    resources :froggo_teams, only: [:index], controller: 'froggo_teams'
+  end
+
   scope path: '/api', defaults: { format: 'json' } do
     api_version(module: "Api::V1", header: { name: "Accept", value: "version=1" }, default: true) do
       resources :repositories, only: [:update]

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "vue-i18n": "^7.4.0",
     "vue-loader": "^15.9.2",
     "vue-template-compiler": "^2.6.11",
+    "vue-toasted": "^1.1.28",
     "vuex": "^3.0.1"
   },
   "version": "0.1.0",

--- a/spec/controllers/api/v1/froggo_teams_controller_spec.rb
+++ b/spec/controllers/api/v1/froggo_teams_controller_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Api::V1::FroggoTeamsController, type: :controller do
 
     context "when everything is ok" do
       before do
-        post :create, params: { name: "new_name", organization_id: platanus_org.id }, format: :json
+        post :create, params: { name: "name", organization_id: platanus_org.id, new_members_ids: [user.id] }, format: :json
       end
 
       it { expect(response).to have_http_status(:ok) }
@@ -107,32 +107,6 @@ RSpec.describe Api::V1::FroggoTeamsController, type: :controller do
       end
 
       it { expect(response).to have_http_status(:no_content) }
-    end
-  end
-
-  describe '#add_member' do
-    context "when the user who wants to add a member is not from the team organization" do
-      before do
-        post :add_member, params: { id: buda_team.id, github_login: user.login }, format: :json
-      end
-
-      it { expect(response).to have_http_status(:bad_request) }
-    end
-
-    context "when the member who is going to be added is not from the organization" do
-      before do
-        post :add_member, params: { id: p_team.id, github_login: "new_user" }, format: :json
-      end
-
-      it { expect(response).to have_http_status(:bad_request) }
-    end
-
-    context "when the member who is going to be added is from the organization" do
-      before do
-        post :add_member, params: { id: p_team.id, github_login: user.login }, format: :json
-      end
-
-      it { expect(response).to have_http_status(:ok) }
     end
   end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10787,6 +10787,11 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
+vue-toasted@^1.1.28:
+  version "1.1.28"
+  resolved "https://registry.yarnpkg.com/vue-toasted/-/vue-toasted-1.1.28.tgz#dbabb83acc89f7a9e8765815e491d79f0dc65c26"
+  integrity sha512-UUzr5LX51UbbiROSGZ49GOgSzFxaMHK6L00JV8fir/CYNJCpIIvNZ5YmS4Qc8Y2+Z/4VVYRpeQL2UO0G800Raw==
+
 vue@^2.5.17, vue@^2.6.11:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"


### PR DESCRIPTION
el objetivo de este PR es agregar en el fornt-end las funcionalidades para ver todos los froggo-teams (index), ver uno en particular (show) y borrar en caso de ser necesario. (los froggo-teams se refiere a los equipos locales que se pueden armar en froggo).

Para esto se crearon las rutas para index y show y la respectiva vista de cada una. Además se agregó un botón en la barra de navegación para que el usuario pudiera acceder a sus equipos y a partir de ahí pudiera decidir si crear uno nuevo, ver alguno en particular o borrarlo.

Este PR no considera editar, es el último que me está faltando :)