### PR TITLE
Profile metrics

### DIFF
--- a/app/commands/get_pull_request_reviews_info.rb
+++ b/app/commands/get_pull_request_reviews_info.rb
@@ -1,0 +1,22 @@
+class GetPullRequestReviewsInfo < PowerTypes::Command.new(:pull_request)
+  def perform
+    @reviews = get_human_reviews
+    reviews_info = Hash.new
+    reviews_info[:first_response] = first_responder.created_at.to_s if first_responder
+    reviews_info[:last_approval] = last_approved.approved_at.to_s if last_approved
+    reviews_info
+  end
+
+  def get_human_reviews
+    monkeyci = GithubUser.find_by(login: "monkeyci")
+    @pull_request.pull_request_reviews.where.not(github_user: monkeyci)
+  end
+
+  def first_responder
+    @reviews.min_by(&:created_at)
+  end
+
+  def last_approved
+    @reviews.where.not(approved_at: nil).max_by(&:approved_at)
+  end
+end

--- a/app/commands/get_user_pull_request_metrics.rb
+++ b/app/commands/get_user_pull_request_metrics.rb
@@ -1,4 +1,4 @@
-class GetUserReviewRequestMetrics < PowerTypes::Command.new(:github_user, :limit_month)
+class GetUserPullRequestMetrics < PowerTypes::Command.new(:github_user, :limit_month)
   MONTH_LIMIT_DEFAULT = 9
 
   def perform

--- a/app/commands/get_user_pull_request_metrics.rb
+++ b/app/commands/get_user_pull_request_metrics.rb
@@ -2,14 +2,11 @@ class GetUserPullRequestMetrics < PowerTypes::Command.new(:github_user, :limit_m
   MONTH_LIMIT_DEFAULT = 9
 
   def perform
-    @entry_count = 0
-    @total_time = 0
     @review_requests_dic = Hash.new
-    @review_requests_dic["pull_requests_information"] = Hash.new
+    @review_requests_dic[:pull_requests_information] = Hash.new
     get_valid_pull_requests.each do |pr|
       add_pr_data_to_hash(pr)
     end
-    @review_requests_dic["personal_mean"] = @entry_count.positive? ? @total_time / @entry_count : 0
     @review_requests_dic
   end
 
@@ -30,21 +27,20 @@ class GetUserPullRequestMetrics < PowerTypes::Command.new(:github_user, :limit_m
     @github_user.pull_requests.where('gh_created_at > ?', limit_date).where.not(merged_by_id: nil)
   end
 
-  def get_pr_info(pull_request, review_req, time_delta)
+  def get_basic_pull_request_info(pull_request, review_request)
     { pr_title: pull_request.title, pr_created_at: pull_request.gh_created_at.to_s,
-      review_request_created_at: review_req.created_at.to_s,
-      time_delta: time_delta }
+      pr_merget_at: pull_request.gh_merged_at.to_s,
+      review_request_created_at: review_request.created_at.to_s }
   end
 
   def add_pr_data_to_hash(pull_request)
-    if review_req = pr_has_review_requests(pull_request)
-      time_delta = (review_req.created_at - pull_request.gh_created_at).to_i
+    if review_request = pr_has_review_requests(pull_request)
+      time_delta = (review_request.created_at - pull_request.gh_created_at).to_i
       unless time_delta > 1.week
-        @entry_count += 1
-        @total_time += time_delta
-        @review_requests_dic["pull_requests_information"][pull_request.id] = get_pr_info(
-          pull_request, review_req, time_delta
-        )
+        current_pull_request_info = get_basic_pull_request_info(pull_request, review_request)
+        current_pull_request_info.merge!(GetPullRequestReviewsInfo.for(pull_request: pull_request))
+        pr_id = pull_request.id
+        @review_requests_dic[:pull_requests_information][pr_id] = current_pull_request_info
       end
     end
   end

--- a/app/controllers/api/v1/github_users_controller.rb
+++ b/app/controllers/api/v1/github_users_controller.rb
@@ -36,7 +36,7 @@ class Api::V1::GithubUsersController < Api::V1::BaseController
 
   def pull_requests_information
     render json: { response: {
-      metrics: GetUserReviewRequestMetrics.for(
+      metrics: GetUserPullRequestMetrics.for(
         github_user: github_user,
         limit_month: permitted_params[:month_limit]
       )

--- a/spec/commands/get_pull_request_reviews_info_spec.rb
+++ b/spec/commands/get_pull_request_reviews_info_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe GetPullRequestReviewsInfo do
+  let(:github_user) { create(:github_user) }
+  let(:monkeyci) { create(:github_user, login: 'monkeyci') }
+  let(:pull_request) { create(:pull_request, owner: github_user) }
+
+  def perform(*_args)
+    described_class.for(*_args)
+  end
+
+  context "when pull request doesn't have any reviews" do
+    it "return empty" do
+      expect(perform(pull_request: pull_request)).to be_empty
+    end
+  end
+
+  context "when pull request has reviews" do
+    context "when pull request has a review from monkeyci" do
+      let!(:monkey_review) do
+        create(
+          :pull_request_review,
+          github_user: monkeyci,
+          pull_request: pull_request,
+          created_at: Time.zone.now - 5.minutes,
+          approved_at: Time.zone.now + 2.minutes
+        )
+      end
+      let!(:human_review) do
+        create(
+          :pull_request_review,
+          github_user: github_user,
+          pull_request: pull_request,
+          created_at: Time.zone.now - 3.minutes,
+          approved_at: Time.zone.now
+        )
+      end
+
+      it "ignores monkey review" do
+        expect(perform(pull_request: pull_request)).to eq(
+          first_response: human_review.created_at.to_s,
+          last_approval: human_review.approved_at.to_s
+        )
+      end
+    end
+
+    context "when pull request doesn't have approval information" do
+      let!(:incomplete_review) do
+        create(
+          :pull_request_review,
+          github_user: github_user,
+          pull_request: pull_request,
+          created_at: Time.zone.now - 3.minutes
+        )
+      end
+
+      it "ignores missing review information" do
+        expect(perform(pull_request: pull_request)).to eq(
+          first_response: incomplete_review.created_at.to_s
+        )
+      end
+    end
+  end
+end

--- a/spec/commands/get_user_pull_request_metrics_spec.rb
+++ b/spec/commands/get_user_pull_request_metrics_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe GetUserReviewRequestMetrics do
+describe GetUserPullRequestMetrics do
   let(:github_user) { create(:github_user) }
   let!(:monkeyci) { create(:github_user, login: 'monkeyci') }
 


### PR DESCRIPTION
En este pr se crea el comando `GetPullRequestReviewsInfo` y se agrega al comando `GetUserPullRequestMetrics` implementado en #246, para ampliar la información que retorna el segundo comando.
Con las adiciones mencionadas el llamado a la API `github_user#pull_requests_information` entregará la siguiente información sobre cada pull request del usuario deseado:
* nombre del pr
* timestamp de creación del pr
* timestamp de la asignación de _reviewers_
* timestamp del primer comentario (puede ser corrección o aprobación por parte del corrector si es que no se piden cambios) recibido
* timestamp de la aprobación del pr
* timestamp del _merge_ del pr