### PR TITLE
feat(FroggoTeams): add froggo teams to teams dashboard

### DIFF
--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -17,6 +17,19 @@ class GithubUser < ApplicationRecord
   validates :login, presence: true
 
   scope :all_except, ->(user) { where.not(id: user) }
+
+  def get_froggo_teams(organization)
+    froggo_teams.filter { |team| team[:organization_id] == organization.id }
+                .map do |team|
+                  {
+                    id: team.id,
+                    name: team.name,
+                    slug: team.slug,
+                    organization_id: organization[:id],
+                    froggo_team: true
+                  }
+                end
+  end
 end
 
 # == Schema Information

--- a/app/views/organizations/_card_header.html.erb
+++ b/app/views/organizations/_card_header.html.erb
@@ -26,8 +26,14 @@
           <%= link_to @github_organization[:login].capitalize, organization_path(name: @github_organization[:login], month_limit: @corrmat.limit), class: 'select__option' %>
 
           <% @teams.each do |team| %>
-            <%= link_to organization_path(name: @github_organization[:login], team: team[:slug], month_limit: @corrmat.limit), class: 'select__option' do %>
+            <% if team[:froggo_team] %>
+              <%= link_to organization_path(name: @github_organization[:login], team: team[:name], month_limit: @corrmat.limit, froggo_team: team[:froggo_team]), class: 'select__option' do %>
+                  <%= team[:name] %>
+              <% end %>
+            <% else %>
+              <%= link_to organization_path(name: @github_organization[:login], team: team[:slug], month_limit: @corrmat.limit, froggo_team: team[:froggo_team]), class: 'select__option' do %>
                 <%= team[:name] %>
+              <% end %>
             <% end %>
           <% end %>
         </div>

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -114,6 +114,7 @@ RSpec.describe OrganizationsController, type: :controller do
 
     before do
       allow(github_session).to receive(:get_teams).and_return([])
+      allow(github_session).to receive(:user) { user }
       get :settings, params: { name: "platanus" }
     end
 


### PR DESCRIPTION
En este PR se integran los equipos locales de froggo junto con los de github. Antes solo al usuario le aparecían los equipos de github en el dropdown y podía seleccionar solo esos. Ahora la idea es que también le aparezcan los equipos locales y tambien pueda hacer click sobre ellos y se despliegue su respectivo dashboard