### PR TITLE
Froggo teams style details

### DIFF
--- a/app/assets/stylesheets/app/froggo_teams.scss
+++ b/app/assets/stylesheets/app/froggo_teams.scss
@@ -58,8 +58,8 @@
 
   &__organization {
     border: 1px solid $gray;
-    margin-top: 5px;
-    margin-bottom: 5px;
+    margin-top: 6px;
+    margin-bottom: 6px;
   }
 
   &__organization-bar {
@@ -76,10 +76,19 @@
   }
 
   &__organization-title {
+    align-items: center;
+    color: $primary;
     display: flex;
-    width: 300px;
-    margin: 0 auto;
-    margin-left: 310px;
+    font-size: 14px;
+    height: 100%;
+    right: 0;
+    text-transform: uppercase;
+    width: auto;
+  }
+
+  &__organization-name {
+    display: flex;
+    width: auto;
     height: 100%;
     right: 0;
     align-items: center;
@@ -108,6 +117,16 @@
     font-family: $roboto-condensed;
     font-size: 16px;
     cursor: pointer;
+  }
+
+  &__organization-team-bar {
+    display: flex;
+    text-decoration: none;
+    width: auto;
+  }
+
+  &__organization-team-name {
+    text-decoration: none;
   }
 
   &__create-button {

--- a/app/javascript/components/froggo-teams-list.vue
+++ b/app/javascript/components/froggo-teams-list.vue
@@ -9,6 +9,8 @@
         <div class="froggo-teams-from-organization__organization-bar">
           <div class="froggo-teams-from-organization__organization-title">
             {{ $t("message.froggoTeams.organizationTitle") }}
+          </div>
+          <div class="froggo-teams-from-organization__organization-name">
             {{ organization.login }}
           </div>
           <div class="froggo-teams-from-organization__organization-create-button">
@@ -24,10 +26,12 @@
           {{ $t("message.froggoTeams.belongedTeams") }}
         </div>
         <div
+          class="froggo-teams-from-organization__organization-team-bar"
           v-for="team in userTeams"
           :key="team.id"
         >
           <a
+            class="froggo-teams-from-organization__organization-team-name"
             :href="`/froggo_teams/${team.id}`"
           >
             <div

--- a/app/javascript/mixins/showMessageMixin.js
+++ b/app/javascript/mixins/showMessageMixin.js
@@ -3,7 +3,7 @@ export default {
     showMessage(message) {
       this.$toasted.show(message, {
         theme: 'toasted-primary',
-        position: 'top-center',
+        position: 'top-right',
         duration: 7000,
       });
     },

--- a/app/views/froggo_teams/_empty.html.erb
+++ b/app/views/froggo_teams/_empty.html.erb
@@ -1,0 +1,6 @@
+<div>
+    <h1 class="card__title"><%= t('messages.froggoTeams.empty_title') %></h1>
+    <div class="card__info">
+      <%= t('messages.froggoTeams.empty_organizations') %>
+    </div>
+</div>

--- a/app/views/froggo_teams/_froggo_teams_list.html.erb
+++ b/app/views/froggo_teams/_froggo_teams_list.html.erb
@@ -1,15 +1,19 @@
 <div class="card">
     <div class="froggo-teams">
         <div class="froggo-teams-list">
-            <div class="froggo-teams-list__title">
-                <%= t('messages.dashboard.my_teams') %>
-            </div>
-            <div class="froggo-teams-list__section">
-                <froggo-teams-list
-                    :user-teams="<%= @user_teams.to_json %>"
-                    :organizations="<%= @organizations.to_json %>"
-                />
-            </div>
+            <% if !@organizations.empty?  %>
+                <div class="froggo-teams-list__title">
+                    <%= t('messages.dashboard.my_teams') %>
+                </div>
+                <div class="froggo-teams-list__section">
+                    <froggo-teams-list
+                        :user-teams="<%= @user_teams.to_json %>"
+                        :organizations="<%= @organizations.to_json %>"
+                    />
+                </div>
+            <% else %>    
+                <%= render "empty" %>
+            <% end %>
         </div>
     </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,3 +111,6 @@ en:
       not_recommended_reviewers: Avoid requesting reviews from these persons
       no_recommendations: You don't belong to any organization so there are no recommendations for you
       give_permissions: Configure organizations
+    froggoTeams:
+      empty_title:  You don't have any Team
+      empty_organizations: To create and see your teams, you need to belong to an organization first

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -84,3 +84,7 @@ es-CL:
       not_recommended_reviewers: Evita mandarle otro PR a estas personas
       no_recommendations: No tenemos recomendaciones para ti dado que no perteneces a ninguna organización
       give_permissions: Configurar organizaciones
+    froggoTeams:
+      empty_title: Aún no tienes equipos!
+      empty_organizations: Para crear y ver tus equipos debes pertenecer a una organización
+      


### PR DESCRIPTION
En este PR moví los mensajes de alerta a la esquina derecha de la pantalla, agregué una view para cuando un usuario no tiene organizaciones y cambié la forma en que se muestran los títulos de los equipos en el froggo-teams-list 