### PR TITLE
Fix pull request reviews approved at

### DIFF
--- a/app/services/github_pull_request_review_service.rb
+++ b/app/services/github_pull_request_review_service.rb
@@ -50,7 +50,11 @@ class GithubPullRequestReviewService < PowerTypes::Service.new(:token)
                                              github_user_id: params[:github_user_id])
       pr_review.update! params
     else
-      pull_request.pull_request_reviews.create!(params)
+      created_review = pull_request.pull_request_reviews.create!(params)
+      if created_review.approved_at? && created_review.approved_at < created_review.created_at
+        created_review.approved_at = created_review.created_at + 1.minute
+        created_review.save!
+      end
     end
   end
 

--- a/db/data/20200909203445_fix_approved_at_values_for_pull_request_reviews.rb
+++ b/db/data/20200909203445_fix_approved_at_values_for_pull_request_reviews.rb
@@ -1,0 +1,13 @@
+class FixApprovedAtValuesForPullRequestReviews < ActiveRecord::Migration[6.0]
+  def up
+    reviews = PullRequestReview.where.not(approved_at: nil).where('approved_at < created_at')
+    reviews.each do |review|
+      review.approved_at += 1.minute
+      review.save
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define()
+DataMigrate::Data.define(version: 20200909203445)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -48,6 +48,9 @@ ActiveRecord::Schema.define(version: 2020_08_25_200237) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "froggo_team_memberships", force: :cascade do |t|
     t.bigint "github_user_id", null: false
     t.bigint "froggo_team_id", null: false


### PR DESCRIPTION
El servicio de manejo de webhooks fallaba en el caso de crear un PullRequestReview record con información de approved_at, ya que el timestamp de approved_at era 1 segundo previo al timestamp de creación del PullRequestReview record. Esto generaba resultados negativos en las métricas de perfil.
Este pr aborda este caso y realiza un data migration para los datos ya registrados