### PR TITLE
feat(pull_request.rb): add more columns to pull request and develop t…

### DIFF
--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -12,6 +12,22 @@ class PullRequestsController < ApplicationController
     )
   end
 
+  def show
+    github_user
+    @pull_request = PullRequest.find(params[:id])
+    @reviewers_id = PullRequestReviewRequest.where(pull_request_id: @pull_request.id)
+    i = 0
+    @reviewers = []
+    loop do
+      @reviewers.push(GithubUser.where(id: @reviewers_id[i].github_user_id))
+      if (i + 1) == @reviewers_id.length
+        break
+      end
+
+      i += 1
+    end
+  end
+
   private
 
   def organization

--- a/app/javascript/components/pr-show.vue
+++ b/app/javascript/components/pr-show.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul
+  <div
     class="card-pr__list"
   >
     <div class="card-pr-title">
@@ -27,65 +27,60 @@
         Likes
       </div>
     </div>
-    <li
-      v-for="pullRequest in prWithLikes"
-      :key="pullRequest.id"
-    >
-      <div class="card-pr__orientation">
-        <div class="card-pr">
-          <a
-            class="card-pr__name"
-            target="_blank"
-            :href="pullRequest.html_url"
+    <div class="card-pr__orientation">
+      <div class="card-pr">
+        <a
+          class="card-pr__name"
+          target="_blank"
+          :href="pullRequest.html_url"
+        >
+          {{ pullRequest.title }}
+        </a>
+        <p
+          v-if="(pullRequest.owner_name)"
+          style="flex: 2;"
+        >
+          {{ pullRequest.owner_name }}
+        </p>
+        <p
+          v-else
+          style="flex: 2;"
+        >
+          {{ $t("message.prFeed.noName") }}
+        </p>
+        <p class="card-pr__project">
+          {{ pullRequest.repository_name }}
+        </p>
+        <p style="flex: 2;">
+          {{ prTime(pullRequest) }}
+        </p>
+        <p style="flex: 2;">
+          {{ prDate(pullRequest) }}
+        </p>
+      </div>
+      <div class="card-pr__card">
+        <p class="card-pr__circle">
+          {{ pullRequest.likes.total }}
+        </p>
+        <div v-if="!(pullRequest.currentUserLike)">
+          <button
+            class="card-pr__button"
+            @click="toggleLike(pullRequest)"
           >
-            {{ pullRequest.title }}
-          </a>
-          <p
-            v-if="(pullRequest.owner_name)"
-            style="flex: 2;"
-          >
-            {{ pullRequest.owner_name }}
-          </p>
-          <p
-            v-else
-            style="flex: 2;"
-          >
-            {{ $t("message.prFeed.noName") }}
-          </p>
-          <p class="card-pr__project">
-            {{ pullRequest.repository_name }}
-          </p>
-          <p style="flex: 2;">
-            {{ prTime(pullRequest) }}
-          </p>
-          <p style="flex: 2;">
-            {{ prDate(pullRequest) }}
-          </p>
+            Like
+          </button>
         </div>
-        <div class="card-pr__card">
-          <p class="card-pr__circle">
-            {{ pullRequest.likes.total }}
-          </p>
-          <div v-if="!(pullRequest.currentUserLike)">
-            <button
-              class="card-pr__button"
-              @click="toggleLike(pullRequest)"
-            >
-              Like
-            </button>
-          </div>
-          <div v-else>
-            <button
-              class="card-pr__button"
-              @click="deleteLike(pullRequest)"
-            >
-              Dislike
-            </button>
-          </div>
+        <div v-else>
+          <button
+            class="card-pr__button"
+            @click="deleteLike(pullRequest)"
+          >
+            Dislike
+          </button>
         </div>
       </div>
-    </li>
-  </ul>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -95,7 +90,7 @@ import moment from 'moment';
 
 export default {
   props: {
-    pullRequests: {
+    pullRequest: {
       type: Array,
       required: true,
     },
@@ -106,13 +101,10 @@ export default {
   },
 
   data() {
-    return {
-      prWithLikes: this.pullRequests.map((pr) => {
-        const liked = this.likesGiven.find((like) => like.likeable_id === pr.id);
+    const pr = this.pullRequest;
+    const liked = this.likesGiven.find((like) => like.likeable_id === pr.id);
 
-        return liked ? { ...pr, currentUserLike: liked } : pr;
-      }),
-    };
+    return liked ? { ...this.pullRequest, currentUserLike: liked } : this.pullRequest;
   },
 
   methods: {

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -48,6 +48,8 @@ end
 #  owner_id      :integer
 #  merged_by_id  :integer
 #  last_change   :datetime
+#  description   :string
+#  commits       :integer
 #
 # Indexes
 #

--- a/app/serializers/pull_request_serializer.rb
+++ b/app/serializers/pull_request_serializer.rb
@@ -1,5 +1,6 @@
 class PullRequestSerializer < ActiveModel::Serializer
-  attributes :id, :title, :repository_name, :owner_id, :html_url, :likes, :created_at, :owner_name
+  attributes :id, :title, :repository_name, :owner_id, :html_url, :likes, :created_at,
+             :owner_name, :description
   def likes
     { total: object.likes.count }
   end

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -74,7 +74,6 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
 
   def build_pull_request_params(repository, github_pull_request)
     owner = GithubUserService.new.find_or_create(github_pull_request.user)
-
     base_params = get_base_params(github_pull_request)
     users_params = { owner_id: owner.id }
 
@@ -114,7 +113,9 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
       gh_created_at: github_pull_request.created_at,
       gh_updated_at: github_pull_request.updated_at,
       gh_closed_at: github_pull_request.closed_at,
-      gh_merged_at: github_pull_request.merged_at
+      gh_merged_at: github_pull_request.merged_at,
+      description: github_pull_request.body,
+      commits: github_pull_request.commits
     }
   end
 

--- a/app/views/pull_requests/show.html.erb
+++ b/app/views/pull_requests/show.html.erb
@@ -1,0 +1,8 @@
+<div id="app" class="app">
+  <%= render 'partials/header' %>
+  <div class="container">
+    <%= @pull_request.title %>
+    <%= @reviewers.to_json%>
+  </div>
+  <%= render "partials/footer" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
     get 'missing' => 'organizations#missing', on: :collection
     get 'settings' => 'organizations#settings', on: :member
     get 'public' => 'organizations#public', on: :member
-    resources :pull_requests, only: [:index]
+    resources :pull_requests, only: [:index, :show]
   end
 
   resources :users, only: [:show], controller: 'github_users'

--- a/db/migrate/20200907192128_add_columns_to_pull_requests.rb
+++ b/db/migrate/20200907192128_add_columns_to_pull_requests.rb
@@ -1,0 +1,7 @@
+class AddColumnsToPullRequests < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pull_requests, :description, :string
+    add_column :pull_requests, :commits, :integer
+    add_column :pull_requests, :reviewers, :string
+  end
+end

--- a/db/migrate/20200909133044_remove_reviewers_from_pull_requests.rb
+++ b/db/migrate/20200909133044_remove_reviewers_from_pull_requests.rb
@@ -1,0 +1,5 @@
+class RemoveReviewersFromPullRequests < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :pull_requests, :reviewers, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -195,6 +195,8 @@ ActiveRecord::Schema.define(version: 2020_09_10_192320) do
     t.integer "owner_id"
     t.integer "merged_by_id"
     t.datetime "last_change"
+    t.string "description"
+    t.integer "commits"
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"
   end
 

--- a/spec/services/github_pull_request_service_spec.rb
+++ b/spec/services/github_pull_request_service_spec.rb
@@ -28,7 +28,9 @@ describe GithubPullRequestService do
       updated_at: "2017-12-12 09:17:52",
       closed_at: "2017-12-12 09:17:52",
       merged_at: nil,
-      user: users[0]
+      user: users[0],
+      body: "merge my great changes!",
+      commits: 1
     )
   end
 
@@ -44,6 +46,8 @@ describe GithubPullRequestService do
       closed_at: "2017-12-12 09:17:52",
       merged_at: "2017-12-12 09:17:52",
       user: users[0],
+      body: "merge my amazing changes!",
+      commits: 5,
       requested_reviewers: [],
       head: double(
         repo: double(


### PR DESCRIPTION
add more columns to pull request and develop the skeleton for the show view

Para el feed donde se muestran las pull requests, faltaba información como la descripción, la cantidad de commits y las personas que la revisaron.
Para las primeras dos, se hicieron dos columnas y se pidieron a través del Webhook cada vez que se crea una nueva PR. Para las personas que la revisaron se usará la otra tabla pull_request_reviewers donde se tiene esa información. Va también con dos migraciones, la segunda simplemente borra la columna de reviewers ya que no se necesitaba finalmente.