### PR TITLE
fix(user-metrics): exclude pull requests with incomplete review infor…

### DIFF
--- a/app/commands/get_user_pull_request_metrics.rb
+++ b/app/commands/get_user_pull_request_metrics.rb
@@ -41,9 +41,12 @@ class GetUserPullRequestMetrics < PowerTypes::Command.new(:github_user, :limit_m
       time_delta = (review_request.created_at - pull_request.gh_created_at).to_i
       unless time_delta > 1.week
         current_pull_request_info = get_basic_pull_request_info(pull_request, review_request)
-        current_pull_request_info.merge!(GetPullRequestReviewsInfo.for(pull_request: pull_request))
-        pr_id = pull_request.id
-        @review_requests_dic[:pull_requests_information][pr_id] = current_pull_request_info
+        pull_request_review_info = GetPullRequestReviewsInfo.for(pull_request: pull_request)
+        unless pull_request_review_info.empty?
+          current_pull_request_info.merge!(pull_request_review_info)
+          pr_id = pull_request.id
+          @review_requests_dic[:pull_requests_information][pr_id] = current_pull_request_info
+        end
       end
     end
   end

--- a/spec/commands/get_user_pull_request_metrics_spec.rb
+++ b/spec/commands/get_user_pull_request_metrics_spec.rb
@@ -33,17 +33,17 @@ describe GetUserPullRequestMetrics do
         created_at: Time.zone.now - 3.minutes
       )
     end
+    let!(:valid_review) do
+      create(
+        :pull_request_review,
+        github_user: github_user,
+        pull_request: valid_pull_request,
+        created_at: Time.zone.now - 2.minutes,
+        approved_at: Time.zone.now - 1.minute
+      )
+    end
 
     context "with valid date limit" do
-      let!(:valid_review) do
-        create(
-          :pull_request_review,
-          github_user: github_user,
-          pull_request: valid_pull_request,
-          created_at: Time.zone.now - 2.minutes,
-          approved_at: Time.zone.now - 1.minute
-        )
-      end
 
       it "return correct information" do
         expect(perform(github_user: github_user, limit_month: 9)).to eq(
@@ -71,8 +71,9 @@ describe GetUserPullRequestMetrics do
       it "ignores review request from monkey" do
         expect(perform(github_user: github_user, limit_month: 9)).to eq(
           pull_requests_information: { valid_pull_request.id => {
-            pr_created_at: valid_pull_request.gh_created_at.to_s,
-            pr_title: "Prueba", pr_number: 123, repository: "MyString",
+            pr_created_at: valid_pull_request.gh_created_at.to_s, pr_title: "Prueba",
+            first_response: valid_review.created_at.to_s, pr_number: 123,
+            last_approval: valid_review.approved_at.to_s, repository: "MyString",
             review_request_created_at: valid_review_request.created_at.to_s,
             pr_merget_at: valid_pull_request.gh_merged_at.to_s
           } }
@@ -99,8 +100,9 @@ describe GetUserPullRequestMetrics do
       it "ignores old pull request" do
         expect(perform(github_user: github_user, limit_month: 9)).to eq(
           pull_requests_information: { valid_pull_request.id => {
-            pr_created_at: valid_pull_request.gh_created_at.to_s,
-            pr_title: "Prueba", pr_number: 123, repository: "MyString",
+            pr_created_at: valid_pull_request.gh_created_at.to_s, pr_title: "Prueba",
+            first_response: valid_review.created_at.to_s, pr_number: 123,
+            last_approval: valid_review.approved_at.to_s, repository: "MyString",
             review_request_created_at: valid_review_request.created_at.to_s,
             pr_merget_at: valid_pull_request.gh_merged_at.to_s
           } }


### PR DESCRIPTION
…mation

En este pr se excluyen los pull request con información incompleta para ser usados en las métricas de perfil. Estos causaban que el gráfico tuviera saltos y los datos de promedio erraran.

<img width="991" alt="Screen Shot 2020-09-10 at 13 18 51" src="https://user-images.githubusercontent.com/30667977/92762237-c5dd8980-f368-11ea-8943-e43bb8bde77b.png">
