### PR TITLE
Unchecked merges metrics

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -47,6 +47,7 @@ end
 #  repository_id :bigint(8)
 #  owner_id      :integer
 #  merged_by_id  :integer
+#  last_change   :datetime
 #
 # Indexes
 #

--- a/app/services/github_pull_request_service.rb
+++ b/app/services/github_pull_request_service.rb
@@ -19,7 +19,14 @@ class GithubPullRequestService < PowerTypes::Service.new(:token)
         data_object.pull_request,
         data_object.requested_reviewer
       )
+    elsif data_object.action === "synchronize" || data_object.action === "edited"
+      update_pull_request_change(pull_request, data_object.pull_request)
     end
+  end
+
+  def update_pull_request_change(pull_request, pull_request_data_object)
+    pull_request.last_change = pull_request_data_object.updated_at
+    pull_request.save!
   end
 
   def import_page_from_repository(repository, page)

--- a/db/migrate/20200910192320_add_last_change_to_pull_request.rb
+++ b/db/migrate/20200910192320_add_last_change_to_pull_request.rb
@@ -1,0 +1,5 @@
+class AddLastChangeToPullRequest < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pull_requests, :last_change, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_25_200237) do
+ActiveRecord::Schema.define(version: 2020_09_10_192320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -194,6 +194,7 @@ ActiveRecord::Schema.define(version: 2020_08_25_200237) do
     t.bigint "repository_id"
     t.integer "owner_id"
     t.integer "merged_by_id"
+    t.datetime "last_change"
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"
   end
 

--- a/spec/factories/pull_requests.rb
+++ b/spec/factories/pull_requests.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     gh_created_at { '2017-12-12 09:17:52' }
     gh_updated_at { '2017-12-12 09:17:52' }
     gh_closed_at { '2017-12-12 09:17:52' }
+    last_change { '2017-12-12 09:17:52' }
 
     association :owner, factory: :github_user
 


### PR DESCRIPTION
En este pr se edita el servicio que maneja los webhooks de pull request, con la intención de guardar el timestamp del último cambio realizado por el autor.
Esta adición será usada para obtener la métrica de "número de pull requests que son editados y mergeados sin una posterior aprobación"