### PR TITLE
feat(github-auth-controller): modify call to github api due to deprec…

### DIFF
--- a/app/controllers/github_auth_controller.rb
+++ b/app/controllers/github_auth_controller.rb
@@ -46,7 +46,9 @@ class GithubAuthController < ApplicationController
     Octokit.client_id = ENV['GH_AUTH_ID']
     Octokit.client_secret = ENV['GH_AUTH_SECRET']
     Octokit.client.as_app do |client|
-      client.delete "/applications/#{ENV['GH_AUTH_ID']}/grants/#{github_session.token}"
+      client.delete("/applications/#{ENV['GH_AUTH_ID']}/grant", {
+                      access_token: github_session.token
+                    })
     end
     true
   rescue Octokit::ApplicationCredentialsRequired, Octokit::Unauthorized


### PR DESCRIPTION
## Objetivo
Modificar la manera que se llama a un _endpoint_ de la API de GitHub porque será deprecado en próximo año

## Descripción
- Me llego un mail diciendo que existían una llamada a GitHub que sería deprecada:
![image](https://user-images.githubusercontent.com/26175977/92970651-67daa000-f455-11ea-89cc-123ca3f8ca95.png)
- En el mail aparecía un [_link_](https://developer.github.com/changes/2020-02-14-deprecating-oauth-app-endpoint/) para corregir ver las modificaciones que se harían:
![image](https://user-images.githubusercontent.com/26175977/92970750-8f316d00-f455-11ea-9769-a275ce01fcfe.png)
![image](https://user-images.githubusercontent.com/26175977/92971071-2a2a4700-f456-11ea-90f1-10cb0b42c18c.png)
- En este caso el _endpoint_ llamado corresponde al `DELETE`
- Por lo tanto se modifica el _path_ para llamar a la API y se incorpora en el body. Sin embargo al parecer está es la manera [de hacerlo](https://docs.github.com/en/rest/reference/apps#delete-an-app-authorization).