### PR TITLE
show only Froggo Teams 

### DIFF
--- a/app/controllers/api/v1/froggo_teams_controller.rb
+++ b/app/controllers/api/v1/froggo_teams_controller.rb
@@ -41,6 +41,9 @@ class Api::V1::FroggoTeamsController < Api::V1::BaseController
   def destroy
     return render(json: { error: "permission denied" }, status: :unauthorized) unless valid_user?
 
+    if organization.default_team_id == froggo_team.id
+      organization.update(default_team_id: nil)
+    end
     froggo_team.destroy
   end
 

--- a/app/controllers/api/v1/froggo_teams_controller.rb
+++ b/app/controllers/api/v1/froggo_teams_controller.rb
@@ -41,9 +41,6 @@ class Api::V1::FroggoTeamsController < Api::V1::BaseController
   def destroy
     return render(json: { error: "permission denied" }, status: :unauthorized) unless valid_user?
 
-    if organization.default_team_id == froggo_team.id
-      organization.update(default_team_id: nil)
-    end
     froggo_team.destroy
   end
 

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -61,7 +61,7 @@ class Api::V1::OrganizationsController < Api::V1::BaseController
   def update_organization_default_team_memberships
     if organization.saved_change_to_attribute?(:default_team_id)
       GithubOrgMembershipService.new(token: @github_session.token)
-                                .import_default_team_members(organization)
+                                .import_default_team_members(organization, params[:froggo_team])
     end
   end
 end

--- a/app/controllers/github_users_controller.rb
+++ b/app/controllers/github_users_controller.rb
@@ -3,7 +3,7 @@ class GithubUsersController < ApplicationController
 
   def show
     @github_user = GithubUser.find(params[:id])
-    @teams = user_teams(@github_user)
+    @teams = froggo_teams
     @organizations = @github_user.organizations
   end
 
@@ -21,7 +21,7 @@ class GithubUsersController < ApplicationController
   end
 
   def froggo_teams
-    github_session.user.get_froggo_teams
+    github_session.user.get_froggo_teams.sort_by { |team| team[:name].downcase }
   end
 
   def user_teams(github_user)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -68,7 +68,7 @@ class OrganizationsController < ApplicationController
   end
 
   def load_matrix_params
-    @teams = user_teams
+    @teams = froggo_teams
     if permitted_params[:team]
       if permitted_params[:froggo_team] == "true"
         @team = FroggoTeam.find_by(name: permitted_params[:team])
@@ -84,10 +84,15 @@ class OrganizationsController < ApplicationController
   end
 
   def load_behaviour_matrix_params
-    @teams = github_teams
+    @teams = froggo_teams
     if @organization.default_team_id
       @team = @teams.find { |team| team[:id] == @organization.default_team_id }
-      @default_team_members_ids = github_team_members&.pluck(:id)
+      if @team[:froggo_team]
+        @team = FroggoTeam.find(@organization.default_team_id)
+        @default_team_members_ids = @team.github_users&.pluck(:gh_id)
+      else
+        @default_team_members_ids = github_team_members&.pluck(:id)
+      end
     end
   end
 
@@ -125,7 +130,7 @@ class OrganizationsController < ApplicationController
   end
 
   def froggo_teams
-    github_session.user.get_froggo_teams_for_organization(@organization)
+    @organization.get_froggo_teams
   end
 
   def user_teams

--- a/app/javascript/components/teams-dropdown.vue
+++ b/app/javascript/components/teams-dropdown.vue
@@ -99,8 +99,9 @@ export default {
       this.$store.dispatch(UPDATE_DEFAULT_TEAM, {
         teamId: team.id,
         organization: this.organization,
+        froggoTeam: team.froggo_team,
       });
-    }
+    },
   },
   components: {
     ClickableDropdown,

--- a/app/javascript/store/modules/admin/actions.js
+++ b/app/javascript/store/modules/admin/actions.js
@@ -5,9 +5,11 @@ import {
 } from '../../action-types';
 
 export default {
-    [UPDATE_DEFAULT_TEAM](
-      {}, { teamId, organization }) {
-      axios
-        .put(`/api/organizations/${organization.id}/update`, { 'default_team_id': teamId });
-    },
-  };
+  [UPDATE_DEFAULT_TEAM](_, { teamId, organization, froggoTeam }) {
+    axios
+      .put(`/api/organizations/${organization.id}/update`, {
+        'default_team_id': teamId,
+        'froggo_team': froggoTeam,
+      });
+  },
+};

--- a/app/models/froggo_team.rb
+++ b/app/models/froggo_team.rb
@@ -1,4 +1,6 @@
 class FroggoTeam < ApplicationRecord
+  include PowerTypes::Observable
+
   has_many :froggo_team_memberships, dependent: :destroy
   has_many :github_users, through: :froggo_team_memberships
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -18,7 +18,9 @@ class Organization < ApplicationRecord
     froggo_teams.map do |team|
       {
         id: team.id,
-        name: team.name
+        name: team.name,
+        organization_id: team.organization_id,
+        froggo_team: true
       }
     end
   end

--- a/app/observers/froggo_team_observer.rb
+++ b/app/observers/froggo_team_observer.rb
@@ -1,0 +1,10 @@
+class FroggoTeamObserver < PowerTypes::Observer
+  after_destroy :update_default_team_id
+
+  def update_default_team_id
+    organization = object.organization
+    if organization.default_team_id == object.id
+      organization.update(default_team_id: nil)
+    end
+  end
+end

--- a/db/data/20200921172413_nullify_default_team_id.rb
+++ b/db/data/20200921172413_nullify_default_team_id.rb
@@ -1,0 +1,9 @@
+class NullifyDefaultTeamId < ActiveRecord::Migration[6.0]
+  def up
+    Organization.update_all(default_team_id: nil)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200909203445)
+DataMigrate::Data.define(version: 20200921172413)

--- a/spec/observers/froggo_team_observer_spec.rb
+++ b/spec/observers/froggo_team_observer_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe FroggoTeamObserver, observers: true do
+  describe "#update_default_team_id" do
+    let(:organization) { create(:organization, default_team_id: 10) }
+    let!(:froggo_team) { create(:froggo_team, id: 10, organization: organization) }
+
+    before do
+      froggo_team.destroy
+    end
+
+    it "if froggo team is the organization's default team sets default_team_id to nil" do
+      expect(Organization.find(organization.id).default_team_id).to be(nil)
+    end
+  end
+end


### PR DESCRIPTION
hasta ahora en froggo existen 2 tipos de equipos, los locales (froggoTeams) y los de github y ambos se muestran a los usuarios. La idea de este PR es que desde ahora solo se muestren equipos de froggo, y dejar de depender de los equipos de github.
Esto significa que por ejemplo desde ahora las organizaciones ya no podrán tener equipos de github como default team, sino que tendrán que elegir un froggoTeam como equipo por default.

