### PR TITLE
fix(user-metrics): update data trimming condition for all zero entries

### DIFF
--- a/app/javascript/components/profile/metrics-handler.vue
+++ b/app/javascript/components/profile/metrics-handler.vue
@@ -128,7 +128,8 @@ export default {
     },
     getTrimmedData() {
       const trimmedData = this.unfilteredData.filter((currValue) => {
-        if (Object.values(currValue).every(value => value === 0)) {
+        if (['creationToAssignmentTime', 'assignmentToResponseTime', 'responseToApprovalTime', 'approvalToMergeTime']
+          .every(key => currValue[key] === 0)) {
           return false;
         }
 


### PR DESCRIPTION
Cebido a que las entradas de unfilteredData poseen también un label, la condición anterior nunca se cumplía. Ahora se itera solamente por las métricas númericas.