### PR TITLE
Update froggo teams show

### DIFF
--- a/app/assets/stylesheets/app/app.scss
+++ b/app/assets/stylesheets/app/app.scss
@@ -12,6 +12,7 @@
 @import './public_dashboard';
 @import './froggo_teams';
 @import './colored_number.scss';
+@import './switch';
 
 *,
 *::after,

--- a/app/assets/stylesheets/app/froggo_teams.scss
+++ b/app/assets/stylesheets/app/froggo_teams.scss
@@ -204,7 +204,7 @@
   }
 
   &__members {
-    margin-bottom: 30px;
+    margin-bottom: 10px;
     padding: 10px;
   }
 
@@ -293,6 +293,24 @@
 
   &__gray-button {
     background: $select-icon-color;
+    border-radius: 2px;
+    color: $white;
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    height: auto;
+    line-height: 30px;
+    margin-left: 10px;
+    min-width: 91px;
+    padding: 2px 5px;
+    text-align: center;
+    text-decoration: none;
+    text-transform: uppercase;
+    vertical-align: middle;
+  }
+
+  &__light-blue-button {
+    background: $primary-color;
     border-radius: 2px;
     color: $white;
     cursor: pointer;

--- a/app/assets/stylesheets/app/froggo_teams.scss
+++ b/app/assets/stylesheets/app/froggo_teams.scss
@@ -216,24 +216,34 @@
   }
 
   &__member-container {
-    display: flex;
-    justify-content: space-between;
     align-items: center;
-    color: $primary;
-    text-decoration: none;
-    margin-bottom: 10px;
     border: 1px solid $primary-border;
+    color: $primary;
+    display: flex;
+    height: 41px;
+    justify-content: flex-end;
+    margin-bottom: 10px;
+    padding: 3px;
+    text-decoration: none;
   }
 
-  &__member {
+  &__member-container-info {
     display: flex;
     align-items: center;
     color: $primary;
+    margin-right: auto;
     text-decoration: none;
 
     &:last-child {
       margin-bottom: 0;
     }
+  }
+
+  &__member-container-options {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    width: 70px;
   }
 
   &__picture {

--- a/app/assets/stylesheets/app/switch.scss
+++ b/app/assets/stylesheets/app/switch.scss
@@ -1,0 +1,44 @@
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 56px;
+  height: 26px;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+  border-radius: 34px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider::before {
+  position: absolute;
+  content: '';
+  height: 22px;
+  width: 22px;
+  left: 3px;
+  bottom: 2px;
+  background-color: $white;
+  transition: .4s;
+  border-radius: 26px;
+}
+
+input:checked + .slider {
+  background-color: $primary-color;
+}
+
+input:checked + .slider::before {
+  transform: translateX(28px);
+}

--- a/app/controllers/api/v1/froggo_teams_controller.rb
+++ b/app/controllers/api/v1/froggo_teams_controller.rb
@@ -98,16 +98,16 @@ class Api::V1::FroggoTeamsController < Api::V1::BaseController
     membership = FroggoTeamMembership.find_by(github_user: github_user, froggo_team: team)
     membership.destroy
   end
-end
 
-def add_members(new_ids_list)
-  new_ids_list.each do |member_id|
-    add_member(member_id, froggo_team)
+  def add_members(new_ids_list)
+    new_ids_list.each do |member_id|
+      add_member(member_id, froggo_team)
+    end
   end
-end
 
-def remove_members(old_ids_list)
-  old_ids_list.each do |member_id|
-    remove_member(member_id, froggo_team)
+  def remove_members(old_ids_list)
+    old_ids_list.each do |member_id|
+      remove_member(member_id, froggo_team)
+    end
   end
 end

--- a/app/controllers/api/v1/froggo_teams_controller.rb
+++ b/app/controllers/api/v1/froggo_teams_controller.rb
@@ -35,6 +35,7 @@ class Api::V1::FroggoTeamsController < Api::V1::BaseController
     end
     add_members(permitted_params[:new_members_ids])
     remove_members(permitted_params[:old_members_ids])
+    update_members_activation
     respond_with froggo_team
   end
 
@@ -48,7 +49,13 @@ class Api::V1::FroggoTeamsController < Api::V1::BaseController
 
   def permitted_params
     params
-      .permit(:name, :id, :organization_id, :github_login, new_members_ids: [], old_members_ids: [])
+      .permit(:name,
+              :id,
+              :organization_id,
+              :github_login,
+              new_members_ids: [],
+              old_members_ids: [],
+              changed_members_ids: [])
       .with_defaults(new_members_ids: [], old_members_ids: [])
   end
 
@@ -108,6 +115,16 @@ class Api::V1::FroggoTeamsController < Api::V1::BaseController
   def remove_members(old_ids_list)
     old_ids_list.each do |member_id|
       remove_member(member_id, froggo_team)
+    end
+  end
+
+  def update_members_activation
+    return unless permitted_params.has_key?(:changed_members_ids)
+
+    permitted_params[:changed_members_ids].each do |member_id|
+      github_user = GithubUser.find_by(id: member_id)
+      membership = FroggoTeamMembership.find_by(github_user: github_user, froggo_team: froggo_team)
+      membership.update(is_member_active: !membership.is_member_active)
     end
   end
 end

--- a/app/controllers/froggo_teams_controller.rb
+++ b/app/controllers/froggo_teams_controller.rb
@@ -15,8 +15,27 @@ class FroggoTeamsController < ApplicationController
 
   def show
     @froggo_team = FroggoTeam.find(params[:id])
-    @froggo_team_members = @froggo_team.github_users
-    @organization_members = @froggo_team.organization.members.all_except(@froggo_team_members)
+    @froggo_team_members = get_froggo_team_members(@froggo_team)
     @github_user = github_user
+  end
+
+  private
+
+  def get_froggo_team_members(froggo_team)
+    froggo_team.github_users.map do |member|
+      {
+        id: member.id,
+        avatar_url: member.avatar_url,
+        gh_id: member.gh_id,
+        login: member.login,
+        name: member.name,
+        active: get_member_activation(member, froggo_team)
+      }
+    end
+  end
+
+  def get_member_activation(member, froggo_team)
+    membership = FroggoTeamMembership.find_by(github_user: member, froggo_team: froggo_team)
+    membership.is_member_active
   end
 end

--- a/app/javascript/components/froggo-team-show.vue
+++ b/app/javascript/components/froggo-team-show.vue
@@ -48,7 +48,7 @@
         :key="user.id"
       >
         <a
-          class="froggo-teams-show__member"
+          class="froggo-teams-show__member-container-info"
           :href="`/users/${user.id}`"
         >
           <img
@@ -59,26 +59,35 @@
             {{ user.login }}
           </div>
         </a>
-        <div
-          class="froggo-teams-show__gray-button"
-          @click="removeMember(user, index)"
-        >
-          {{ $t("message.froggoTeams.deleteFromTeam") }}
+        <div class="froggo-teams-show__member-container-options">
+          <label class="switch">
+            <input
+              type="checkbox"
+              @click="changeMemberActivation(user)"
+            >
+            <span class="slider" />
+          </label>
+          <div
+            class="froggo-teams-show__gray-button"
+            @click="removeMember(user, index)"
+          >
+            {{ $t("message.froggoTeams.deleteFromTeam") }}
+          </div>
         </div>
       </div>
     </div>
     <div class="froggo-teams-show__end-section">
       <div
         class="froggo-teams-show__gray-button"
-        @click="saveFroggoTeam"
-      >
-        {{ $t("message.froggoTeams.saveTeam") }}
-      </div>
-      <div
-        class="froggo-teams-show__gray-button"
         @click="deleteFroggoTeam"
       >
         {{ $t("message.froggoTeams.deleteTeam") }}
+      </div>
+      <div
+        class="froggo-teams-show__gray-button"
+        @click="saveFroggoTeam"
+      >
+        {{ $t("message.froggoTeams.saveTeam") }}
       </div>
     </div>
   </div>
@@ -170,6 +179,10 @@ export default {
         this.usersToAdd.splice(index, 1);
       }
       this.$store.commit(REMOVE_MEMBER, { index: userIndex, member: user });
+    },
+    changeMemberActivation(user) {
+      console.log('apretado');
+      console.log(user);
     },
     saveFroggoTeam() {
       this.$store.dispatch(UPDATE_FROGGO_TEAM, {

--- a/app/javascript/components/froggo-team-show.vue
+++ b/app/javascript/components/froggo-team-show.vue
@@ -2,49 +2,17 @@
   <div class="froggo-teams-show">
     <div class="froggo-teams-show__name">
       <div class="froggo-teams-show__name-container">
-        {{ teamName }}
-      </div>
-      <div
-        class="froggo-teams-show__white-button"
-        @click="editFroggoTeamName"
-      >
-        {{ $t("message.froggoTeams.editName") }}
-      </div>
-    </div>
-    <div
-      class="froggo-teams-show__edit-name-section"
-      v-if="editName"
-    >
-      <input
-        type="text"
-        v-model="newName"
-      >
-      <div
-        class="froggo-teams-show__gray-button"
-        @click="submitName()"
-      >
-        {{ $t("message.froggoTeams.saveName") }}
+        {{ froggoTeam.name }}
       </div>
     </div>
     <div class="froggo-teams-show__members">
       <div class="froggo-teams-show__member-title">
-        {{ $t("message.froggoTeams.addMember") }}
-      </div>
-      <div class="froggo-teams-show__dropdown">
-        <clickable-dropdown
-          :body-title="dropdownTitle"
-          :no-items-message="noUsersMessage"
-          :items="possibleMembers"
-          @item-clicked="onItemClicked"
-        />
-      </div>
-      <div class="froggo-teams-show__member-title">
         {{ $t("message.froggoTeams.members") }}
-        ( {{ membersCounter }} )
+        ( {{ froggoTeamMembers.length }} )
       </div>
       <div
         class="froggo-teams-show__member-container"
-        v-for="(user, index) in currentMembers"
+        v-for="(user) in froggoTeamMembers"
         :key="user.id"
       >
         <a
@@ -63,73 +31,45 @@
           <label class="switch">
             <input
               type="checkbox"
+              :checked="user.active"
               @click="changeMemberActivation(user)"
             >
             <span class="slider" />
           </label>
-          <div
-            class="froggo-teams-show__gray-button"
-            @click="removeMember(user, index)"
-          >
-            {{ $t("message.froggoTeams.deleteFromTeam") }}
-          </div>
         </div>
       </div>
     </div>
     <div class="froggo-teams-show__end-section">
       <div
-        class="froggo-teams-show__gray-button"
-        @click="deleteFroggoTeam"
+        class="froggo-teams-show__white-button"
+        @click="editTeam"
       >
-        {{ $t("message.froggoTeams.deleteTeam") }}
+        {{ $t("message.froggoTeams.editTeam") }}
       </div>
       <div
-        class="froggo-teams-show__gray-button"
-        @click="saveFroggoTeam"
+        class="froggo-teams-show__light-blue-button"
+        @click="saveMembersState"
       >
-        {{ $t("message.froggoTeams.saveTeam") }}
+        {{ $t("message.froggoTeams.saveChanges") }}
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import { mapState } from 'vuex';
 import {
   UPDATE_FROGGO_TEAM,
-  DELETE_FROGGO_TEAM,
 } from '../store/action-types';
-import {
-  TEAM_NAME,
-  LOAD_MEMBERS,
-  ADD_MEMBER,
-  REMOVE_MEMBER,
-} from '../store/mutation-types';
-import ClickableDropdown from './clickable-dropdown';
 import showMessageMixin from '../mixins/showMessageMixin';
 
 export default {
   mixins: [showMessageMixin],
-  beforeMount() {
-    this.$store.commit(TEAM_NAME, this.froggoTeam.name);
-    this.$store.commit(LOAD_MEMBERS, { members: this.froggoTeamMembers,
-      possibleMembers: this.organizationMembers });
-  },
   data() {
     return {
-      dropdownTitle: 'Usuarios',
-      noUsersMessage: 'No se encontraron usuarios',
-      editName: false,
-      newName: '',
-      usersToAdd: [],
-      usersToRemove: [],
+      originalMembersStates: this.loadMembersStates(),
     };
   },
   props: {
-    userId: {
-      type: Number,
-      required: true,
-    },
     froggoTeam: {
       type: Object,
       required: true,
@@ -138,87 +78,41 @@ export default {
       type: Array,
       required: true,
     },
-    organizationMembers: {
-      type: Array,
-      required: true,
-    },
   },
   methods: {
-    editFroggoTeamName() {
-      this.editName = !this.editName;
+    changeMemberActivation(user) {
+      user.active = !user.active;
     },
-    submitName() {
+    saveMembersState() {
       this.$store.dispatch(UPDATE_FROGGO_TEAM, {
-        name: this.newName,
         id: this.froggoTeam.id,
+        changedMembersIds: this.getChangedMembersIds(),
       })
         .then(() => {
-          this.$store.commit(TEAM_NAME, this.newName);
+          this.showMessage(this.$i18n.t('message.froggoTeams.successfullySavedChanges'));
         })
         .catch(() => {
-          this.showMessage(this.$i18n.t('message.error.existentName'));
+          this.showMessage(this.$i18n.t('message.settings.error'));
         });
     },
-    onItemClicked({ item }) {
-      this.addMember(item);
+    getChangedMembersIds() {
+      const changedMembers = this.froggoTeamMembers
+        .filter(member => member.active !== this.originalMembersStates[member.id]);
+
+      return changedMembers.map(user => user.id);
     },
-    addMember(user) {
-      if (this.froggoTeamMembers.some(u => u.id === user.id)) {
-        const index = this.usersToRemove.findIndex(u => u.id === user.id);
-        this.usersToRemove.splice(index, 1);
-      } else {
-        this.usersToAdd = [...this.usersToAdd, user];
-      }
-      this.$store.commit(ADD_MEMBER, user);
+    editTeam() {
+      window.location.href = `/froggo_teams/${this.froggoTeam.id}/edit`;
     },
-    removeMember(user, userIndex) {
-      if (this.froggoTeamMembers.some(u => u.id === user.id)) {
-        this.usersToRemove = [...this.usersToRemove, user];
-      } else {
-        const index = this.usersToAdd.findIndex(u => u.id === user.id);
-        this.usersToAdd.splice(index, 1);
-      }
-      this.$store.commit(REMOVE_MEMBER, { index: userIndex, member: user });
+    loadMembersStates() {
+      const membersState = {};
+
+      this.froggoTeamMembers.forEach((team) => {
+        membersState[team.id] = team.active;
+      });
+
+      return membersState;
     },
-    changeMemberActivation(user) {
-      console.log('apretado');
-      console.log(user);
-    },
-    saveFroggoTeam() {
-      this.$store.dispatch(UPDATE_FROGGO_TEAM, {
-        newMembersIds: this.usersToAdd.map(user => user.id),
-        oldMembersIds: this.usersToRemove.map(user => user.id),
-        id: this.froggoTeam.id,
-      })
-        .then(() => {
-          this.showMessage(this.$i18n.t('message.froggoTeams.successfullySavedTeam'));
-          this.usersToAdd = [];
-          this.usersToRemove = [];
-        });
-    },
-    deleteFroggoTeam() {
-      this.$store.dispatch(DELETE_FROGGO_TEAM, {
-        id: this.froggoTeam.id,
-      })
-        .then(response => {
-          if (response) {
-            window.location.href = `/github_users/${this.userId}/froggo_teams`;
-          }
-        });
-    },
-  },
-  components: {
-    ClickableDropdown,
-  },
-  computed: {
-    membersCounter() {
-      return this.currentMembers.length;
-    },
-    ...mapState({
-      teamName: state => state.froggoTeam.teamName,
-      currentMembers: state => state.froggoTeam.currentMembers,
-      possibleMembers: state => state.froggoTeam.possibleMembers,
-    }),
   },
 };
 </script>

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -48,9 +48,10 @@ export default {
       saveName: 'Save name',
       members: 'Members: ',
       deleteFromTeam: 'Delete member',
-      saveTeam: 'Save team',
+      saveChanges: 'Save changes',
+      editTeam: 'Edit Team',
       deleteTeam: 'Delete team',
-      successfullySavedTeam: 'Team was successfully saved',
+      successfullySavedChanges: 'Changes were successfully saved',
       successfullyCreatedTeam: 'Team was successfully created',
     },
     prFeed: {

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -48,9 +48,10 @@ export default {
       saveName: 'Guardar nombre',
       members: 'Miembros: ',
       deleteFromTeam: 'Quitar del equipo',
-      saveTeam: 'Guardar equipo',
+      saveChanges: 'Guardar cambios',
+      editTeam: 'Editar equipo',
       deleteTeam: 'Eliminar equipo',
-      successfullySavedTeam: 'Equipo guardado exitosamente',
+      successfullySavedChanges: 'Cambios guardados exitosamente',
       successfullyCreatedTeam: 'Equipo creado exitosamente',
     },
     prFeed: {

--- a/app/javascript/store/modules/froggo_team/actions.js
+++ b/app/javascript/store/modules/froggo_team/actions.js
@@ -12,9 +12,9 @@ export default {
       `/api/organizations/${organizationId}/froggo_teams`, decamelizeKeys({ name, newMembersIds: userIds }));
   },
 
-  [UPDATE_FROGGO_TEAM](_, { id, name, newMembersIds, oldMembersIds }) {
+  [UPDATE_FROGGO_TEAM](_, { id, name, newMembersIds, oldMembersIds, changedMembersIds }) {
     return axios.patch(
-      `/api/froggo_teams/${id}`, decamelizeKeys({ name, newMembersIds, oldMembersIds }));
+      `/api/froggo_teams/${id}`, decamelizeKeys({ name, newMembersIds, oldMembersIds, changedMembersIds }));
   },
 
   [DELETE_FROGGO_TEAM](_, { id }) {

--- a/app/models/froggo_team_membership.rb
+++ b/app/models/froggo_team_membership.rb
@@ -7,11 +7,12 @@ end
 #
 # Table name: froggo_team_memberships
 #
-#  id             :bigint(8)        not null, primary key
-#  github_user_id :bigint(8)        not null
-#  froggo_team_id :bigint(8)        not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id               :bigint(8)        not null, primary key
+#  github_user_id   :bigint(8)        not null
+#  froggo_team_id   :bigint(8)        not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  is_member_active :boolean          default(TRUE)
 #
 # Indexes
 #

--- a/app/views/froggo_teams/show.html.erb
+++ b/app/views/froggo_teams/show.html.erb
@@ -4,10 +4,8 @@
     <div class="card">
       <div class="froggo-teams">
         <froggo-team-show
-          :user-id="<%= @github_user.id %>"
           :froggo-team="<%= @froggo_team.to_json %>"
           :froggo-team-members="<%= @froggo_team_members.to_json %>"
-          :organization-members="<%= @organization_members.to_json %>"
         />
       </div>
     </div>

--- a/db/data/20200923161151_add_true_value_to_is_member_active.rb
+++ b/db/data/20200923161151_add_true_value_to_is_member_active.rb
@@ -1,0 +1,9 @@
+class AddTrueValueToIsMemberActive < ActiveRecord::Migration[6.0]
+  def up
+    FroggoTeamMembership.update_all(is_member_active: true)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200921172413)
+DataMigrate::Data.define(version: 20200923161151)

--- a/db/migrate/20200923140921_add_member_active_to_froggo_team_memberships.rb
+++ b/db/migrate/20200923140921_add_member_active_to_froggo_team_memberships.rb
@@ -1,0 +1,10 @@
+class AddMemberActiveToFroggoTeamMemberships < ActiveRecord::Migration[6.0]
+  def up
+    add_column :froggo_team_memberships, :is_member_active, :boolean
+    change_column_default :froggo_team_memberships, :is_member_active, true
+  end
+
+  def down
+    remove_column :froggo_team_memberships, :is_member_active
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_10_192320) do
+ActiveRecord::Schema.define(version: 2020_09_23_140921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2020_09_10_192320) do
     t.bigint "froggo_team_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "is_member_active", default: true
     t.index ["froggo_team_id"], name: "index_froggo_team_memberships_on_froggo_team_id"
     t.index ["github_user_id"], name: "index_froggo_team_memberships_on_github_user_id"
   end


### PR DESCRIPTION
Antes el path de froggo teams show, mostraba una vista con el equipo froggo team  (sus miembros y características) y además se podía editar el equipo desde ahí mismo. Ahora la idea es que existan 2 vistas separadas ... una que sea show y otra que sea edit. La idea es que show solo muestre al equipo y se puedan activar y desactivar sus miembros, y que edit permita editar las características del equipo como el nombre, miembros, etc.

En este PR está el nuevo "show", que por una parte ya no incluye los métodos de edición que antes incluía y por otra agrega una nueva funcionalidad que es la de activar o desactivar miembros del equipo, a través de un botón switch. La idea de esto último es que para cada equipo se pueda setear si un miembro está o no activo (por ejemplo se debería poder desactivar un miembro que está de vacaciones), lo que se hace a través del atributo "is_member_active" del modelo FroggoTeamMembership

Aquí van fotos del antes y el después ... le falta un poco de cariño al diseño 😓 , pero eso lo vamos a ver después 

Antes: 

![image](https://user-images.githubusercontent.com/37182412/94190233-36fd6080-fe82-11ea-8e78-54853d6e7b24.png)

Después:

![Captura de pantalla 2020-09-24 a la(s) 16 20 25](https://user-images.githubusercontent.com/37182412/94190309-4c728a80-fe82-11ea-9a4b-8cba712395d4.png)


