### PR TITLE
Froggo teams edit

### DIFF
--- a/app/controllers/froggo_teams_controller.rb
+++ b/app/controllers/froggo_teams_controller.rb
@@ -19,6 +19,13 @@ class FroggoTeamsController < ApplicationController
     @github_user = github_user
   end
 
+  def edit
+    @froggo_team = FroggoTeam.find(params[:id])
+    @froggo_team_members = @froggo_team.github_users
+    @organization_members = @froggo_team.organization.members.all_except(@froggo_team_members)
+    @github_user = github_user
+  end
+
   private
 
   def get_froggo_team_members(froggo_team)

--- a/app/javascript/components/froggo-team-edit.vue
+++ b/app/javascript/components/froggo-team-edit.vue
@@ -1,0 +1,211 @@
+<template>
+  <div class="froggo-teams-show">
+    <div class="froggo-teams-show__name">
+      <div class="froggo-teams-show__name-container">
+        {{ teamName }}
+      </div>
+      <div
+        class="froggo-teams-show__white-button"
+        @click="editFroggoTeamName"
+      >
+        {{ $t("message.froggoTeams.editName") }}
+      </div>
+    </div>
+    <div
+      class="froggo-teams-show__edit-name-section"
+      v-if="editName"
+    >
+      <input
+        type="text"
+        v-model="newName"
+      >
+      <div
+        class="froggo-teams-show__gray-button"
+        @click="submitName()"
+      >
+        {{ $t("message.froggoTeams.saveName") }}
+      </div>
+    </div>
+    <div class="froggo-teams-show__members">
+      <div class="froggo-teams-show__member-title">
+        {{ $t("message.froggoTeams.addMember") }}
+      </div>
+      <div class="froggo-teams-show__dropdown">
+        <clickable-dropdown
+          :body-title="dropdownTitle"
+          :no-items-message="noUsersMessage"
+          :items="possibleMembers"
+          @item-clicked="onItemClicked"
+        />
+      </div>
+      <div class="froggo-teams-show__member-title">
+        {{ $t("message.froggoTeams.members") }}
+        ( {{ membersCounter }} )
+      </div>
+      <div
+        class="froggo-teams-show__member-container"
+        v-for="(user, index) in currentMembers"
+        :key="user.id"
+      >
+        <a
+          class="froggo-teams-show__member-container-info"
+          :href="`/users/${user.id}`"
+        >
+          <img
+            class="froggo-teams-show__picture"
+            :src="user.avatar_url"
+          >
+          <div class="froggo-teams-show__username">
+            {{ user.login }}
+          </div>
+        </a>
+        <div
+          class="froggo-teams-show__gray-button"
+          @click="removeMember(user, index)"
+        >
+          {{ $t("message.froggoTeams.deleteFromTeam") }}
+        </div>
+      </div>
+    </div>
+    <div class="froggo-teams-show__end-section">
+      <div
+        class="froggo-teams-show__gray-button"
+        @click="deleteFroggoTeam"
+      >
+        {{ $t("message.froggoTeams.deleteTeam") }}
+      </div>
+      <div
+        class="froggo-teams-show__gray-button"
+        @click="saveFroggoTeam"
+      >
+        {{ $t("message.froggoTeams.saveChanges") }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import {
+  UPDATE_FROGGO_TEAM,
+  DELETE_FROGGO_TEAM,
+} from '../store/action-types';
+import {
+  TEAM_NAME,
+  LOAD_MEMBERS,
+  ADD_MEMBER,
+  REMOVE_MEMBER,
+} from '../store/mutation-types';
+import ClickableDropdown from './clickable-dropdown';
+import showMessageMixin from '../mixins/showMessageMixin';
+
+export default {
+  mixins: [showMessageMixin],
+  beforeMount() {
+    this.$store.commit(TEAM_NAME, this.froggoTeam.name);
+    this.$store.commit(LOAD_MEMBERS, { members: this.froggoTeamMembers,
+      possibleMembers: this.organizationMembers });
+  },
+  data() {
+    return {
+      dropdownTitle: 'Usuarios',
+      noUsersMessage: 'No se encontraron usuarios',
+      editName: false,
+      newName: '',
+      usersToAdd: [],
+      usersToRemove: [],
+    };
+  },
+  props: {
+    userId: {
+      type: Number,
+      required: true,
+    },
+    froggoTeam: {
+      type: Object,
+      required: true,
+    },
+    froggoTeamMembers: {
+      type: Array,
+      required: true,
+    },
+    organizationMembers: {
+      type: Array,
+      required: true,
+    },
+  },
+  methods: {
+    editFroggoTeamName() {
+      this.editName = !this.editName;
+    },
+    submitName() {
+      this.$store.dispatch(UPDATE_FROGGO_TEAM, {
+        name: this.newName,
+        id: this.froggoTeam.id,
+      })
+        .then(() => {
+          this.$store.commit(TEAM_NAME, this.newName);
+        })
+        .catch(() => {
+          this.showMessage(this.$i18n.t('message.error.existentName'));
+        });
+    },
+    onItemClicked({ item }) {
+      this.addMember(item);
+    },
+    addMember(user) {
+      if (this.froggoTeamMembers.some(u => u.id === user.id)) {
+        const index = this.usersToRemove.findIndex(u => u.id === user.id);
+        this.usersToRemove.splice(index, 1);
+      } else {
+        this.usersToAdd = [...this.usersToAdd, user];
+      }
+      this.$store.commit(ADD_MEMBER, user);
+    },
+    removeMember(user, userIndex) {
+      if (this.froggoTeamMembers.some(u => u.id === user.id)) {
+        this.usersToRemove = [...this.usersToRemove, user];
+      } else {
+        const index = this.usersToAdd.findIndex(u => u.id === user.id);
+        this.usersToAdd.splice(index, 1);
+      }
+      this.$store.commit(REMOVE_MEMBER, { index: userIndex, member: user });
+    },
+    saveFroggoTeam() {
+      this.$store.dispatch(UPDATE_FROGGO_TEAM, {
+        newMembersIds: this.usersToAdd.map(user => user.id),
+        oldMembersIds: this.usersToRemove.map(user => user.id),
+        id: this.froggoTeam.id,
+      })
+        .then(() => {
+          this.showMessage(this.$i18n.t('message.froggoTeams.successfullySavedChanges'));
+          this.usersToAdd = [];
+          this.usersToRemove = [];
+        });
+    },
+    deleteFroggoTeam() {
+      this.$store.dispatch(DELETE_FROGGO_TEAM, {
+        id: this.froggoTeam.id,
+      })
+        .then(response => {
+          if (response) {
+            window.location.href = `/github_users/${this.userId}/froggo_teams`;
+          }
+        });
+    },
+  },
+  components: {
+    ClickableDropdown,
+  },
+  computed: {
+    membersCounter() {
+      return this.currentMembers.length;
+    },
+    ...mapState({
+      teamName: state => state.froggoTeam.teamName,
+      currentMembers: state => state.froggoTeam.currentMembers,
+      possibleMembers: state => state.froggoTeam.possibleMembers,
+    }),
+  },
+};
+</script>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,6 +11,7 @@ import { camelizeKeys } from 'humps';
 import Dropdown from '../components/pl-dropdown.vue';
 import TeamsDropdown from '../components/teams-dropdown.vue';
 import OrganizationsDropdown from '../components/organizations-dropdown.vue';
+import FroggoTeamEdit from '../components/froggo-team-edit.vue';
 import FroggoTeamForm from '../components/froggo-team-form.vue';
 import FroggoTeamShow from '../components/froggo-team-show.vue';
 import FroggoTeamsList from '../components/froggo-teams-list.vue';
@@ -50,6 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
   Vue.component('dropdown', Dropdown);
   Vue.component('teams-dropdown', TeamsDropdown);
   Vue.component('organizations-dropdown', OrganizationsDropdown);
+  Vue.component('froggo-team-edit', FroggoTeamEdit);
   Vue.component('froggo-team-form', FroggoTeamForm);
   Vue.component('froggo-team-show', FroggoTeamShow);
   Vue.component('froggo-teams-list', FroggoTeamsList);

--- a/app/views/froggo_teams/edit.html.erb
+++ b/app/views/froggo_teams/edit.html.erb
@@ -1,0 +1,15 @@
+<div id="app" class="app">
+  <%= render 'partials/header' %>
+  <div class="container">
+    <div class="card">
+      <div class="froggo-teams">
+        <froggo-team-edit
+          :user-id="<%= @github_user.id %>"
+          :froggo-team="<%= @froggo_team.to_json %>"
+          :froggo-team-members="<%= @froggo_team_members.to_json %>"
+          :organization-members="<%= @organization_members.to_json %>"
+        />
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
   end
 
   resources :froggo_teams, only: [:show], controller: 'froggo_teams'
+  get 'froggo_teams/:id/edit' => 'froggo_teams#edit'
 
   scope path: '/api', defaults: { format: 'json' } do
     api_version(module: "Api::V1", header: { name: "Accept", value: "version=1" }, default: true) do


### PR DESCRIPTION
Este PR crea la vista para froggo_teams edit. En esta vista la idea es que el usuario pueda cambiar el nombre del equipo, agregar miembros, eliminar miembros o eliminar al equipo completo. (se que le falta cariño al diseño 😅  jajajja pero más adelante está contemplado mejorar eso).
Esta es la vista:

![Captura de pantalla 2020-09-28 a la(s) 10 54 14](https://user-images.githubusercontent.com/37182412/94441315-fd29a400-0178-11eb-9899-5f00859c42e9.png)
