### PR TITLE
Froggo teams active members

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ group :development, :test do
   gem 'rubocop-performance'
   gem 'rubocop-rails', '~> 2.4.2'
   gem 'rubocop-rspec', '~> 1.38.0'
+  gem 'timecop'
 end
 
 group :production, :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,6 +470,7 @@ GEM
     thread_safe (0.3.6)
     thwait (0.1.0)
     tilt (2.0.10)
+    timecop (0.9.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -566,6 +567,7 @@ DEPENDENCIES
   simple_token_authentication (~> 1.0)
   spring
   strong_migrations
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/commands/compute_color_score.rb
+++ b/app/commands/compute_color_score.rb
@@ -1,5 +1,5 @@
 class ComputeColorScore < PowerTypes::Command.new(:user_id, :team_users_ids, :pr_relations,
-                                                  review_month_limit: nil)
+                                                  review_month_limit: nil, team_id: nil)
   REVIEW_MONTH_LIMIT_DEFAULT = 9
 
   def perform
@@ -21,16 +21,37 @@ class ComputeColorScore < PowerTypes::Command.new(:user_id, :team_users_ids, :pr
   def score_for_other_user(other_user_id)
     return -1 if mean_prs_sent.zero?
 
-    (reviews_per_user[other_user_id] || 0).to_f / mean_prs_sent
+    return (reviews_per_user[other_user_id] || 0).to_f / mean_prs_sent if @team_id.nil?
+
+    user_active_days = active_days[other_user_id]
+    (reviews_per_user[other_user_id] || 0).to_f / (mean_prs_sent * user_active_days)
   end
 
   def mean_prs_sent
     @mean_prs_sent ||= compute_mean_prs_sent
   end
 
+  def period_start
+    @period_start ||= Time.current - review_month_limit.month
+  end
+
+  def period_days
+    @period_days ||= Time.current.to_date - period_start.to_date
+  end
+
+  def organization_id
+    @organization_id ||= if @team_id
+                           FroggoTeam.find(@team_id).organization_id
+                         end
+  end
+
   def compute_mean_prs_sent
     other_users_ids = @team_users_ids - [@user_id]
-    other_users_ids.empty? ? 0.0 : reviews_per_user.values.sum.to_f / other_users_ids.length
+    if @team_id
+      other_users_ids.empty? ? 0.0 : daily_reviews_per_user.values.sum.to_f / other_users_ids.length
+    else
+      other_users_ids.empty? ? 0.0 : reviews_per_user.values.sum.to_f / other_users_ids.length
+    end
   end
 
   def reviews_per_user
@@ -40,5 +61,57 @@ class ComputeColorScore < PowerTypes::Command.new(:user_id, :team_users_ids, :pr
                                        .where.not(github_user_id: @user_id)
                                        .group(:github_user_id)
                                        .count
+  end
+
+  def daily_reviews_per_user
+    @daily_reviews_per_user ||= reviews_per_user.map { |id, pr| [id, (pr / active_days[id].to_f)] }
+                                                .to_h
+  end
+
+  def active_days
+    @active_days ||= users_active_days
+  end
+
+  def users_active_days
+    active_days = {}
+    @team_users_ids.each do |user_id|
+      next if @user_id == user_id
+
+      active_days[user_id] = get_active_time(user_id).to_i
+    end
+    active_days
+  end
+
+  def get_active_time(user_id)
+    org_membership = OrganizationMembership.find_by(github_user_id: user_id,
+                                                    organization_id: organization_id)
+    team_membership = FroggoTeamMembership.find_by(github_user_id: user_id,
+                                                   froggo_team_id: @team_id)
+    membership_time(org_membership) - inactivity_time(team_membership)
+  end
+
+  def membership_time(membership)
+    days_being_member = Time.current.to_date - membership.created_at.to_date
+    if days_being_member > period_days
+      return period_days
+
+    elsif days_being_member.zero?
+      return 1
+    end
+
+    days_being_member
+  end
+
+  def inactivity_time(membership)
+    if membership.last_activation_date.nil? || membership.last_activation_date < period_start
+      return 0
+    end
+
+    days_off = if membership.last_deactivation_date > period_start
+                 membership.last_activation_date.to_date - membership.last_deactivation_date.to_date
+               else
+                 membership.last_activation_date.to_date - period_start.to_date
+               end
+    days_off
   end
 end

--- a/app/commands/get_review_recommendations.rb
+++ b/app/commands/get_review_recommendations.rb
@@ -1,5 +1,5 @@
 class GetReviewRecommendations < PowerTypes::Command.new(:github_user_id, :other_users_ids,
-                                                         month_limit: nil)
+                                                         month_limit: nil, froggo_team_id: nil)
   NUMBER_OF_RECOMMENDATIONS = 3
 
   def perform
@@ -16,7 +16,8 @@ class GetReviewRecommendations < PowerTypes::Command.new(:github_user_id, :other
     @color_scores ||= begin
       pr_relations = PullRequestRelation.review_relations
       ComputeColorScore.for(user_id: @github_user_id, team_users_ids: @other_users_ids,
-                            pr_relations: pr_relations, review_month_limit: @month_limit)
+                            pr_relations: pr_relations, review_month_limit: @month_limit,
+                            team_id: @froggo_team_id)
     end
   end
 

--- a/app/controllers/api/v1/github_users_controller.rb
+++ b/app/controllers/api/v1/github_users_controller.rb
@@ -69,6 +69,7 @@ class Api::V1::GithubUsersController < Api::V1::BaseController
     end
     GithubUser
       .where(gh_id: team_members_gh_ids)
+      .reject { |user| active_member(user) == false }
       .pluck(:id)
       .reject { |id| id == github_user.id }
       .sort
@@ -93,6 +94,15 @@ class Api::V1::GithubUsersController < Api::V1::BaseController
                         permitted_params[:from] || Date.new,
                         permitted_params[:to] || Date.today
                       )
+  end
+
+  def active_member(user)
+    if permitted_params[:froggo_team] == "false"
+      return true
+    end
+
+    membership = FroggoTeamMembership.find_by(github_user: user, froggo_team: froggo_team)
+    membership.is_member_active
   end
 
   def permitted_params

--- a/app/controllers/api/v1/github_users_controller.rb
+++ b/app/controllers/api/v1/github_users_controller.rb
@@ -20,7 +20,8 @@ class Api::V1::GithubUsersController < Api::V1::BaseController
       recommendations: GetReviewRecommendations.for(
         github_user_id: github_user.id,
         other_users_ids: other_team_members_ids,
-        month_limit: permitted_params[:month_limit]&.to_i
+        month_limit: permitted_params[:month_limit]&.to_i,
+        froggo_team_id: froggo_team_id
       )
     } }, status: :ok
   end
@@ -85,6 +86,12 @@ class Api::V1::GithubUsersController < Api::V1::BaseController
 
   def froggo_team
     @froggo_team ||= FroggoTeam.find_by!(id: permitted_params[:team_id])
+  end
+
+  def froggo_team_id
+    @froggo_team_id ||= if permitted_params[:froggo_team] == "true"
+                          froggo_team.id
+                        end
   end
 
   def pr_relations

--- a/app/javascript/components/froggo-team-show.vue
+++ b/app/javascript/components/froggo-team-show.vue
@@ -90,6 +90,7 @@ export default {
       })
         .then(() => {
           this.showMessage(this.$i18n.t('message.froggoTeams.successfullySavedChanges'));
+          window.location.reload(true);
         })
         .catch(() => {
           this.showMessage(this.$i18n.t('message.settings.error'));

--- a/app/models/froggo_team_membership.rb
+++ b/app/models/froggo_team_membership.rb
@@ -1,6 +1,18 @@
 class FroggoTeamMembership < ApplicationRecord
+  after_update :update_activation_date, if: :saved_change_to_is_member_active?
+
   belongs_to :github_user
   belongs_to :froggo_team
+
+  private
+
+  def update_activation_date
+    if is_member_active?
+      update(last_activation_date: Time.current)
+    else
+      update(last_deactivation_date: Time.current)
+    end
+  end
 end
 
 # == Schema Information

--- a/app/models/froggo_team_membership.rb
+++ b/app/models/froggo_team_membership.rb
@@ -7,12 +7,14 @@ end
 #
 # Table name: froggo_team_memberships
 #
-#  id               :bigint(8)        not null, primary key
-#  github_user_id   :bigint(8)        not null
-#  froggo_team_id   :bigint(8)        not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  is_member_active :boolean          default(TRUE)
+#  id                     :bigint(8)        not null, primary key
+#  github_user_id         :bigint(8)        not null
+#  froggo_team_id         :bigint(8)        not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  is_member_active       :boolean          default(TRUE)
+#  last_deactivation_date :datetime
+#  last_activation_date   :datetime
 #
 # Indexes
 #

--- a/db/migrate/20200929135242_add_last_deactivation_date_to_froggo_team_memberships.rb
+++ b/db/migrate/20200929135242_add_last_deactivation_date_to_froggo_team_memberships.rb
@@ -1,0 +1,5 @@
+class AddLastDeactivationDateToFroggoTeamMemberships < ActiveRecord::Migration[6.0]
+  def change
+    add_column :froggo_team_memberships, :last_deactivation_date, :datetime
+  end
+end

--- a/db/migrate/20200929135252_add_last_activation_date_to_froggo_team_memberships.rb
+++ b/db/migrate/20200929135252_add_last_activation_date_to_froggo_team_memberships.rb
@@ -1,0 +1,5 @@
+class AddLastActivationDateToFroggoTeamMemberships < ActiveRecord::Migration[6.0]
+  def change
+    add_column :froggo_team_memberships, :last_activation_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_140921) do
+ActiveRecord::Schema.define(version: 2020_09_29_135252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,8 @@ ActiveRecord::Schema.define(version: 2020_09_23_140921) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "is_member_active", default: true
+    t.datetime "last_deactivation_date"
+    t.datetime "last_activation_date"
     t.index ["froggo_team_id"], name: "index_froggo_team_memberships_on_froggo_team_id"
     t.index ["github_user_id"], name: "index_froggo_team_memberships_on_github_user_id"
   end
@@ -195,9 +197,9 @@ ActiveRecord::Schema.define(version: 2020_09_23_140921) do
     t.bigint "repository_id"
     t.integer "owner_id"
     t.integer "merged_by_id"
-    t.datetime "last_change"
     t.string "description"
     t.integer "commits"
+    t.datetime "last_change"
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"
   end
 

--- a/spec/models/froggo_team_membership_spec.rb
+++ b/spec/models/froggo_team_membership_spec.rb
@@ -1,8 +1,67 @@
 require 'rails_helper'
 
 RSpec.describe FroggoTeamMembership, type: :model do
+  let!(:user) { create(:github_user) }
+  let!(:organization) { create(:organization) }
+  let!(:team) { create(:froggo_team, organization: organization) }
+
   describe 'relationships' do
     it { is_expected.to belong_to(:github_user) }
     it { is_expected.to belong_to(:froggo_team) }
+  end
+
+  describe 'update callback' do
+    let(:current_date) { Time.zone.local(1996, 12, 17) }
+
+    before do
+      Timecop.freeze(current_date)
+    end
+
+    context "when member is deactivated" do
+      let(:membership) do
+        create(
+          :froggo_team_membership,
+          github_user: user,
+          froggo_team: team
+        )
+      end
+
+      def deactivate_membership
+        membership.update(is_member_active: false)
+      end
+
+      it "membership last_deactivation_date is updated" do
+        expect { deactivate_membership }.to change { membership.last_deactivation_date }
+          .to(current_date)
+      end
+
+      it "membership last_activation_date is not changed" do
+        expect { deactivate_membership }.not_to (change { membership.last_activation_date })
+      end
+    end
+
+    context "when member is activated" do
+      let(:membership) do
+        create(
+          :froggo_team_membership,
+          github_user: user,
+          froggo_team: team,
+          is_member_active: false
+        )
+      end
+
+      def activate_membership
+        membership.update(is_member_active: true)
+      end
+
+      it "membership last_activation_date is updated" do
+        expect { activate_membership }.to change { membership.last_activation_date }
+          .to(current_date)
+      end
+
+      it "membership last_deactivation_date is not changed" do
+        expect { activate_membership }.not_to (change { membership.last_deactivation_date })
+      end
+    end
   end
 end


### PR DESCRIPTION
La idea de este PR es implementar la activación y desactivación de miembros de un equipo, y calcular las recomendaciones considerando la actividad de los usuarios. Para ello, se definieron dos cosas principalmente. La primera es que cuando un usuario esté inactivo, este no le aparezca en las recomendaciones de sus compañeros de equipo. Y la segunda es evitar que cuando un usuario que haya estado desactivado varios días se vuelva activar, le llegue un gran número de PR. Esto último se hizo utilizando una nueva fórmula para calcular el puntaje de cada usuario, que ahora solo considera los días en que el usuario ha estado activo.