### PR TITLE
fix(index.html.erb): fixed bug that treated string as method

### DIFF
--- a/app/views/pull_requests/index.html.erb
+++ b/app/views/pull_requests/index.html.erb
@@ -5,7 +5,7 @@
       <pr-feed
         :pull-requests="<%= @serialized_pull_requests.to_json %> | camelizeKeys"
         :likes-given="<%= @likes_given.to_json %> | camelizeKeys"
-        :organization_name="<%= @organization_name %> | camelizeKeys" >
+        organization-name="<%= @organization_name %>" >
       </pr-feed>
       <div class="card-pr__pagination">
         <%= paginate @pull_requests %>


### PR DESCRIPTION
En frog se tenía el bug de que se de rails se entregaba un string pero Vue lo recibía como un método por lo que no cargaba la página.

El error se veía así:

<img width="1440" alt="Screen Shot 2020-10-05 at 11 41 39 AM" src="https://user-images.githubusercontent.com/17711310/95095962-1515a080-0702-11eb-8c8b-47c6d851d754.png">

Para arreglarlo se eliminaron los ":" que hacía que Vue pensara que era un método y se quitó el camelizeKeys para que no pensara que era una clase. Ahora funciona correctamente.