### PR TITLE
fix(_gap.html.erb): fixed bug of pagination

### DIFF
--- a/app/assets/stylesheets/app/card.scss
+++ b/app/assets/stylesheets/app/card.scss
@@ -181,11 +181,14 @@ $roboto: 'Roboto', sans-serif;
 
     &__background {
       background-color: $white;
+      display: block;
+      text-align: center;
     }
 
     &__pagination {
       text-align: center;
-      margin-bottom: 10px;
+      margin-bottom: 50px;
+      display: inline-block;
     }
 
     &__project {

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap" ><%= t('views.pagination.truncate').html_safe %></span>
+<span class="page gap" > ... </span>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -7,7 +7,7 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <nav class="pagination" style="color:green; font-family:'Roboto', sans-serif; font-size: 20px; text-decoration: none;" role="navigation" aria-label="pager">
+  <nav class="pagination" style="font-family:'Roboto', sans-serif; font-size: 20px; text-decoration: none;" role="navigation" aria-label="pager">
     <%= first_page_tag unless current_page.first? %>
     <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>


### PR DESCRIPTION
Arreglo muy chico de loa paginación. Donde sale Truncate se cambió para que salgan "..." y además se dio margen con el display abajo de la paginación:

<img width="608" alt="Screen Shot 2020-10-05 at 4 05 31 PM" src="https://user-images.githubusercontent.com/17711310/95120904-a1d15600-0724-11eb-89d6-79accd1c993c.png">

Quedando así:

<img width="660" alt="Screen Shot 2020-10-05 at 4 07 00 PM" src="https://user-images.githubusercontent.com/17711310/95121029-d5ac7b80-0724-11eb-81f0-4ca79ff0ec2a.png">
