### PR TITLE
Froggo organization dashboard users

### DIFF
--- a/app/assets/stylesheets/app/profile.scss
+++ b/app/assets/stylesheets/app/profile.scss
@@ -292,6 +292,7 @@
     text-align: center;
     opacity: .9;
     box-shadow: 1px 1px 3px 0 rgba(0, 0, 0, .5);
+    white-space: pre-wrap;
   }
 
   .tooltip-arrow {

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -5,6 +5,8 @@ class OrganizationsController < ApplicationController
   before_action :load_organization_by_name, only: [:public]
   before_action :ensure_organization_admin, only: :settings
 
+  MONTH_LIMIT_DEFAULT = 9
+
   def index
     if github_organizations.empty?
       redirect_to missing_organizations_path
@@ -18,6 +20,8 @@ class OrganizationsController < ApplicationController
     @organizations = github_organizations
     set_corrmat
     @color_scores = get_color_scores
+    @belonged_team = @team_members_ids.nil? ? false : @team_members_ids.include?(github_user.gh_id)
+    @inactive_days = get_members_inactive_days
   end
 
   def create
@@ -113,6 +117,10 @@ class OrganizationsController < ApplicationController
     @behaviour_matrix = get_behaviour_matrix(@organization.id, @default_team_members_ids)
   end
 
+  def month_limit
+    @month_limit ||= MONTH_LIMIT_DEFAULT
+  end
+
   def redirect_to_default_organization
     redirect_to organization_path(name: github_session.organizations.first[:login])
   end
@@ -194,10 +202,31 @@ class OrganizationsController < ApplicationController
   end
 
   def get_team_id
-    if @team && permitted_params[:froggo_team] == "true"
-      return @team.id
+    permitted_params[:froggo_team] == "true" ? @team&.id : nil
+  end
+
+  def get_members_inactive_days
+    return unless @team
+
+    inactive_days = {}
+    period_start = Time.current - month_limit.month
+    @team.github_users.each do |user|
+      membership = FroggoTeamMembership.find_by(github_user: user, froggo_team: @team)
+      inactive_days[user.id] = get_inactive_days(membership, period_start)
+    end
+    inactive_days
+  end
+
+  def get_inactive_days(membership, period_start)
+    if membership.last_activation_date.nil? || membership.last_activation_date < period_start
+      return 0
     end
 
-    nil
+    days_off = if membership.last_deactivation_date > period_start
+                 membership.last_activation_date.to_date - membership.last_deactivation_date.to_date
+               else
+                 membership.last_activation_date.to_date - period_start.to_date
+               end
+    days_off.to_i
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -176,7 +176,8 @@ class OrganizationsController < ApplicationController
 
     ComputeColorScore.for(
       user_id: github_user.id, team_users_ids: get_other_users_ids,
-      pr_relations: get_pr_relations, review_month_limit: @month_limit
+      pr_relations: get_pr_relations, review_month_limit: @month_limit,
+      team_id: get_team_id
     )
   end
 
@@ -190,5 +191,13 @@ class OrganizationsController < ApplicationController
     return PullRequestRelation.by_organizations(@organization.id) unless @month_limit
 
     PullRequestRelation.by_organizations(@organization.id).within_month_limit(@month_limit)
+  end
+
+  def get_team_id
+    if @team && permitted_params[:froggo_team] == "true"
+      return @team.id
+    end
+
+    nil
   end
 end

--- a/app/javascript/components/organization-matrix-head.vue
+++ b/app/javascript/components/organization-matrix-head.vue
@@ -1,0 +1,89 @@
+<template>
+  <div
+    class="matrix__head"
+    id="sticky-head"
+  >
+    <div
+      class="matrix__user-head"
+      v-for="(user, index) in correlationMatrix.selected_users"
+      :key="user.id"
+    >
+      <div class="matrix__picture">
+        <a
+          :href="`/users/${user.id}`"
+        >
+          <div
+            class="matrix__user-div"
+            v-if="index == correlationMatrix.min_ranking_indexes[0]"
+          >
+            <div>
+              <img
+                class="matrix__user-img"
+                :src="user.avatar_url"
+                v-tooltip="getTooltipMessage(user, index)"
+              >
+            </div>
+            <img
+              class="matrix__user-crown"
+              src="/assets/dashboard-img-crown-67e7b8e051ce7e158602beaf5d625e6ebb4e6156d56fc4266215911c87eb47df.svg"
+            >
+          </div>
+          <img
+            v-else
+            :class="getClass(index)"
+            :src="user.avatar_url"
+            v-tooltip="getTooltipMessage(user, index)"
+          >
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    correlationMatrix: {
+      type: Object,
+      required: true,
+    },
+    colorScores: {
+      type: Object,
+      default: null,
+    },
+    belongedTeam: {
+      type: Boolean,
+      default: false,
+    },
+    inactiveDays: {
+      type: Object,
+      default: null,
+    },
+  },
+  methods: {
+    getClass(index) {
+      if (index === this.correlationMatrix.min_ranking_indexes[1]) {
+        return 'matrix__user-img--second';
+      } else if (index === this.correlationMatrix.min_ranking_indexes[2]) {
+        return 'matrix__user-img--third';
+      }
+
+      return 'matrix__user-img';
+    },
+    getTooltipMessage(user, index) {
+      if (!this.belongedTeam || index === 0) {
+        return user.login;
+      }
+
+      const userInfo = user.login.concat(' \n',
+        this.$t('message.organization.members.inactiveDays'),
+        this.inactiveDays[user.id],
+        ' \n',
+        this.$t('message.organization.members.score'),
+        this.colorScores[user.id]);
+
+      return userInfo;
+    },
+  },
+};
+</script>

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -93,5 +93,11 @@ export default {
       hour: 'hour',
       minute: 'minute',
     },
+    organization: {
+      members: {
+        inactiveDays: 'Inactive days: ',
+        score: 'Score: ',
+      },
+    },
   },
 };

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -93,5 +93,11 @@ export default {
       hour: 'hora',
       minute: 'minuto',
     },
+    organization: {
+      members: {
+        inactiveDays: 'Días inactivos: ',
+        score: 'Puntaje: ',
+      },
+    },
   },
 };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -28,6 +28,7 @@ import PrFeed from '../components/pr-feed.vue';
 import PrShow from '../components/pr-show.vue';
 import ProfileMetrics from '../components/profile/metrics.vue';
 import FroggoTeamMetrics from '../components/froggo-team-metrics.vue';
+import OrganizationMatrixHead from '../components/organization-matrix-head.vue';
 
 import Locales from '../locales/locales.js';
 import store from '../store';
@@ -67,6 +68,7 @@ document.addEventListener('DOMContentLoaded', () => {
   Vue.component('pr-show', PrShow);
   Vue.component('profile-metrics', ProfileMetrics);
   Vue.component('froggo-team-metrics', FroggoTeamMetrics);
+  Vue.component('organization-matrix-head', OrganizationMatrixHead);
 
   if (document.getElementById('app') !== null) {
     new Vue({ // eslint-disable-line no-new

--- a/app/views/organizations/_dashboard_table.html.erb
+++ b/app/views/organizations/_dashboard_table.html.erb
@@ -19,18 +19,12 @@
           <% end %>
         </div>
         <div class="matrix__values">
-          <div class="matrix__head" id="sticky-head">
-            <% @corrmat.selected_users.each_with_index do |user, i| %>
-              <div class="matrix__user-head">
-                <div class="matrix__picture">
-                  <%= render partial: 'ranked_user_avatar',
-                    locals: { user: user,
-                              correlation_matrix: @corrmat,
-                              user_index: i } %>
-                </div>
-              </div>
-            <% end %>
-          </div>
+          <organization-matrix-head
+            :correlation-matrix="<%= @corrmat.to_json %>"
+            :color-scores ="<%= @color_scores.to_json %>"
+            :belonged-team = "<%= @belonged_team.to_json %>"
+            :inactive-days = "<%= @inactive_days.to_json %>">
+          </organization-matrix-head>
           <% @corrmat.selected_users.each_with_index do |b, i| %>
             <div class="matrix__row">
               <% @corrmat.selected_users.each_with_index do |a, j| %>


### PR DESCRIPTION
La idea de este PR es que en la vista de organizaciones de froggo, en el dashboard, al poner el mouse sobre algún usuario muestre su nombre, su puntaje, y los días que ha estado inactivo o de vacaciones.
Para eso se tuvo que construir un nuevo componente en vue: organization-matrix-head, y a cada imagen implementar la clase tooltip.

Aquí una imagen del antes y el después:
Antes:
![Captura de pantalla 2020-10-06 a la(s) 10 52 30](https://user-images.githubusercontent.com/37182412/95210992-6d13dc00-07c2-11eb-9dda-ece99eec1d2b.png)

Después
![Captura de pantalla 2020-10-06 a la(s) 10 54 50](https://user-images.githubusercontent.com/37182412/95211001-700ecc80-07c2-11eb-8ab4-4d437396c112.png)
