### PR TITLE
Filter pr

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+//= link froggo-logo.svg

--- a/app/assets/stylesheets/app/card.scss
+++ b/app/assets/stylesheets/app/card.scss
@@ -183,11 +183,14 @@ $roboto: 'Roboto', sans-serif;
       background-color: $white;
       display: block;
       text-align: center;
+      padding: 0;
+      margin-top: 0;
+      overflow: auto;
     }
 
     &__pagination {
       text-align: center;
-      margin-bottom: 50px;
+      margin-bottom: 25px;
       display: inline-block;
     }
 
@@ -353,6 +356,7 @@ $roboto: 'Roboto', sans-serif;
       font-size: 26px;
       margin-top: 20px;
       font-family: Arial Rounded MT Bold;
+      margin-bottom: 20px;
 
       &__header {
         display: flex;

--- a/app/commands/filter_pull_requests.rb
+++ b/app/commands/filter_pull_requests.rb
@@ -1,0 +1,17 @@
+class FilterPullRequests < PowerTypes::Command.new(:all_pull_requests, :options)
+  def perform
+    filter(:project_name) { |pr| pr.by_repository(@options[:project_name]) }
+    # filter(:owner) { |pr| pr.by_repository(@options[:project_name]) }
+    pull_requests
+  end
+
+  private
+
+  def pull_requests
+    @pull_requests ||= @all_pull_requests
+  end
+
+  def filter(_option)
+    @pull_requests = yield pull_requests if @options.key? _option
+  end
+end

--- a/app/commands/filter_pull_requests.rb
+++ b/app/commands/filter_pull_requests.rb
@@ -1,7 +1,7 @@
 class FilterPullRequests < PowerTypes::Command.new(:all_pull_requests, :options)
   def perform
     filter(:project_name) { |pr| pr.by_repository(@options[:project_name]) }
-    # filter(:owner) { |pr| pr.by_repository(@options[:project_name]) }
+    filter(:owner_name) { |pr| pr.by_owner(@options[:owner_name]) }
     pull_requests
   end
 

--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -6,8 +6,9 @@ class PullRequestsController < ApplicationController
     @organization_name = organization_name
     @pull_requests = PullRequest.by_organizations(
       [organization.id]
-    ).order(created_at: :desc).page(params[:page])
-    @pull_requests = FilterPullRequests.for(all_pull_requests: @pull_requests, options: filtering_params)
+    ).order(created_at: :desc)
+    @pull_requests = FilterPullRequests.for(all_pull_requests: @pull_requests,
+                                            options: filtering_params)
     @pull_requests = @pull_requests.page(params[:page])
     @serialized_pull_requests = ActiveModel::Serializer::CollectionSerializer.new(
       @pull_requests, each_serializer: PullRequestSerializer
@@ -37,6 +38,6 @@ class PullRequestsController < ApplicationController
   end
 
   def filtering_params
-    params.permit(:project_name)
+    params.permit(:project_name, :owner_name)
   end
 end

--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -7,6 +7,8 @@ class PullRequestsController < ApplicationController
     @pull_requests = PullRequest.by_organizations(
       [organization.id]
     ).order(created_at: :desc).page(params[:page])
+    @pull_requests = FilterPullRequests.for(all_pull_requests: @pull_requests, options: filtering_params)
+    @pull_requests = @pull_requests.page(params[:page])
     @serialized_pull_requests = ActiveModel::Serializer::CollectionSerializer.new(
       @pull_requests, each_serializer: PullRequestSerializer
     )
@@ -32,5 +34,9 @@ class PullRequestsController < ApplicationController
 
   def organization_name
     params.require(:organization_name)
+  end
+
+  def filtering_params
+    params.permit(:project_name)
   end
 end

--- a/app/javascript/components/pr-feed.vue
+++ b/app/javascript/components/pr-feed.vue
@@ -2,9 +2,6 @@
   <ul
     class="card-pr__list"
   >
-    <div class="card-pr-title">
-      Feed
-    </div>
     <li
       v-for="pullRequest in prWithLikes"
       :key="pullRequest.id"

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -22,7 +22,11 @@ class PullRequest < ApplicationRecord
   end
 
   scope :by_repository, ->(repository) do
-    joins(:repository).where("repositories.name LIKE ?", "%#{repository}%")
+    joins(:repository).where("LOWER(repositories.name) LIKE LOWER(?)", "%#{repository}%")
+  end
+
+  scope :by_owner, ->(owner) do
+    joins(:owner).where("LOWER(github_users.login) LIKE LOWER(?)", "%#{owner}%")
   end
 
   validates :gh_id, presence: true

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -21,6 +21,10 @@ class PullRequest < ApplicationRecord
     joins(:repository).where(repositories: { organization_id: organization_ids })
   end
 
+  scope :by_repository, ->(repository) do
+    joins(:repository).where("repositories.name LIKE ?", "%#{repository}%")
+  end
+
   validates :gh_id, presence: true
   validates :pr_state, presence: true, inclusion: { in: %w(open closed) }
 

--- a/app/views/pull_requests/index.html.erb
+++ b/app/views/pull_requests/index.html.erb
@@ -2,6 +2,11 @@
   <%= render 'partials/header' %>
   <div class="container">
     <div class="card-pr__background">
+      <form action="/organizations/<%= @organization_name %>/pull_requests">
+        <label for="project_name">Proyecto:</label>
+        <input type="text" id="project_name" name="project_name">
+        <input type="submit" value="Submit">
+      </form>
       <pr-feed
         :pull-requests="<%= @serialized_pull_requests.to_json %> | camelizeKeys"
         :likes-given="<%= @likes_given.to_json %> | camelizeKeys"

--- a/app/views/pull_requests/index.html.erb
+++ b/app/views/pull_requests/index.html.erb
@@ -2,9 +2,17 @@
   <%= render 'partials/header' %>
   <div class="container">
     <div class="card-pr__background">
+      <div class="card-pr-title">
+        Feed
+      </div>
       <form action="/organizations/<%= @organization_name %>/pull_requests">
         <label for="project_name">Proyecto:</label>
         <input type="text" id="project_name" name="project_name">
+        <input type="submit" value="Submit">
+      </form>
+      <form action="/organizations/<%= @organization_name %>/pull_requests">
+        <label for="owner_name">Autor :</label>
+        <input type="text" id="owner_name" name="owner_name">
         <input type="submit" value="Submit">
       </form>
       <pr-feed


### PR DESCRIPTION
El feed se presentan todas las pull requests que hay en platanus. Esto claramente es un problema por las decenas que se hacen diarias y se dificulta la búsqueda de un PR en específico. Para esto se decidió hacer filtros.

Se agregan dos filtros de texto para las pull requests. El primero es según el nombre del proyecto y el segundo según el nombre del creador de la PR.

Por ahora el diseño no es tan importante y se ve de la siguiente manera:
<img width="471" alt="Screen Shot 2020-10-07 at 4 37 28 PM" src="https://user-images.githubusercontent.com/17711310/95379541-e3483980-08bb-11eb-9a1a-d5008ed7afb8.png">

Estos filtros permiten manejarse mejor navegando en el Feed
