### PR TITLE
Froggo team members percentage

### DIFF
--- a/app/commands/compute_color_score.rb
+++ b/app/commands/compute_color_score.rb
@@ -24,7 +24,8 @@ class ComputeColorScore < PowerTypes::Command.new(:user_id, :team_users_ids, :pr
     return (reviews_per_user[other_user_id] || 0).to_f / mean_prs_sent if @team_id.nil?
 
     user_active_days = active_days[other_user_id]
-    (reviews_per_user[other_user_id] || 0).to_f / (mean_prs_sent * user_active_days)
+    user_pr_rate = pull_request_rate(other_user_id)
+    (reviews_per_user[other_user_id] || 0).to_f / (mean_prs_sent * user_active_days * user_pr_rate)
   end
 
   def mean_prs_sent
@@ -113,5 +114,11 @@ class ComputeColorScore < PowerTypes::Command.new(:user_id, :team_users_ids, :pr
                  membership.last_activation_date.to_date - period_start.to_date
                end
     days_off
+  end
+
+  def pull_request_rate(user_id)
+    membership = FroggoTeamMembership.find_by(github_user_id: user_id,
+                                              froggo_team_id: @team_id)
+    membership.assignment_percentage.to_f / 100
   end
 end

--- a/app/controllers/api/v1/froggo_teams_controller.rb
+++ b/app/controllers/api/v1/froggo_teams_controller.rb
@@ -36,6 +36,7 @@ class Api::V1::FroggoTeamsController < Api::V1::BaseController
     add_members(permitted_params[:new_members_ids])
     remove_members(permitted_params[:old_members_ids])
     update_members_activation
+    update_members_percentage
     respond_with froggo_team
   end
 
@@ -55,7 +56,8 @@ class Api::V1::FroggoTeamsController < Api::V1::BaseController
               :github_login,
               new_members_ids: [],
               old_members_ids: [],
-              changed_members_ids: [])
+              changed_members_ids: [],
+              changed_percentages: {})
       .with_defaults(new_members_ids: [], old_members_ids: [])
   end
 
@@ -125,6 +127,15 @@ class Api::V1::FroggoTeamsController < Api::V1::BaseController
       github_user = GithubUser.find_by(id: member_id)
       membership = FroggoTeamMembership.find_by(github_user: github_user, froggo_team: froggo_team)
       membership.update(is_member_active: !membership.is_member_active)
+    end
+  end
+
+  def update_members_percentage
+    return unless permitted_params.has_key?(:changed_percentages)
+
+    permitted_params[:changed_percentages].each do |member_id, percentage|
+      membership = FroggoTeamMembership.find_by(github_user_id: member_id, froggo_team: froggo_team)
+      membership.update(assignment_percentage: percentage)
     end
   end
 end

--- a/app/controllers/froggo_teams_controller.rb
+++ b/app/controllers/froggo_teams_controller.rb
@@ -15,7 +15,7 @@ class FroggoTeamsController < ApplicationController
 
   def show
     @froggo_team = FroggoTeam.find(params[:id])
-    @froggo_team_members = get_froggo_team_members(@froggo_team)
+    @froggo_team_members = froggo_team_members(@froggo_team)
     @github_user = github_user
   end
 
@@ -28,21 +28,22 @@ class FroggoTeamsController < ApplicationController
 
   private
 
-  def get_froggo_team_members(froggo_team)
+  def froggo_team_members(froggo_team)
     froggo_team.github_users.map do |member|
-      {
-        id: member.id,
-        avatar_url: member.avatar_url,
-        gh_id: member.gh_id,
-        login: member.login,
-        name: member.name,
-        active: get_member_activation(member, froggo_team)
-      }
+      member_info(member, froggo_team)
     end
   end
 
-  def get_member_activation(member, froggo_team)
+  def member_info(member, froggo_team)
     membership = FroggoTeamMembership.find_by(github_user: member, froggo_team: froggo_team)
-    membership.is_member_active
+    {
+      id: member.id,
+      avatar_url: member.avatar_url,
+      gh_id: member.gh_id,
+      login: member.login,
+      name: member.name,
+      active: membership.is_member_active,
+      percentage: membership.assignment_percentage
+    }
   end
 end

--- a/app/javascript/components/froggo-team-show.vue
+++ b/app/javascript/components/froggo-team-show.vue
@@ -12,7 +12,7 @@
       </div>
       <div
         class="froggo-teams-show__member-container"
-        v-for="(user) in froggoTeamMembers"
+        v-for="(user) in teamMembers"
         :key="user.id"
       >
         <a
@@ -28,6 +28,10 @@
           </div>
         </a>
         <div class="froggo-teams-show__member-container-options">
+          <input
+            type="text"
+            v-model="user.percentage"
+          >
           <label class="switch">
             <input
               type="checkbox"
@@ -57,16 +61,18 @@
 </template>
 
 <script>
+import showMessageMixin from '../mixins/showMessageMixin';
 import {
   UPDATE_FROGGO_TEAM,
 } from '../store/action-types';
-import showMessageMixin from '../mixins/showMessageMixin';
 
 export default {
   mixins: [showMessageMixin],
   data() {
     return {
       originalMembersStates: this.loadMembersStates(),
+      originalMembersPercentages: this.loadMembersPercentages(),
+      teamMembers: this.froggoTeamMembers,
     };
   },
   props: {
@@ -86,7 +92,8 @@ export default {
     saveMembersState() {
       this.$store.dispatch(UPDATE_FROGGO_TEAM, {
         id: this.froggoTeam.id,
-        changedMembersIds: this.getChangedMembersIds(),
+        changedMembersIds: this.changedMembersIds,
+        changedPercentages: this.changedPercentages,
       })
         .then(() => {
           this.showMessage(this.$i18n.t('message.froggoTeams.successfullySavedChanges'));
@@ -96,23 +103,42 @@ export default {
           this.showMessage(this.$i18n.t('message.settings.error'));
         });
     },
-    getChangedMembersIds() {
-      const changedMembers = this.froggoTeamMembers
-        .filter(member => member.active !== this.originalMembersStates[member.id]);
-
-      return changedMembers.map(user => user.id);
-    },
     editTeam() {
       window.location.href = `/froggo_teams/${this.froggoTeam.id}/edit`;
     },
     loadMembersStates() {
       const membersState = {};
 
-      this.froggoTeamMembers.forEach((team) => {
-        membersState[team.id] = team.active;
+      this.froggoTeamMembers.forEach((member) => {
+        membersState[member.id] = member.active;
       });
 
       return membersState;
+    },
+    loadMembersPercentages() {
+      const membersPercentages = {};
+
+      this.froggoTeamMembers.forEach((member) => {
+        membersPercentages[member.id] = member.percentage;
+      });
+
+      return membersPercentages;
+    },
+  },
+  computed: {
+    changedMembersIds() {
+      return this.teamMembers
+        .filter(member => member.active !== this.originalMembersStates[member.id])
+        .map(user => user.id);
+    },
+    changedPercentages() {
+      return this.teamMembers
+        .filter(member => member.percentage !== this.originalMembersPercentages[member.id])
+        .reduce((finalObj, member) => {
+          finalObj[member.id] = member.percentage;
+
+          return finalObj;
+        }, {});
     },
   },
 };

--- a/app/javascript/store/modules/froggo_team/actions.js
+++ b/app/javascript/store/modules/froggo_team/actions.js
@@ -19,9 +19,11 @@ export default {
       `/api/organizations/${organizationId}/froggo_teams`, decamelizeKeys({ name, newMembersIds: userIds }));
   },
 
-  [UPDATE_FROGGO_TEAM](_, { id, name, newMembersIds, oldMembersIds, changedMembersIds }) {
+  [UPDATE_FROGGO_TEAM](_, { id, name, newMembersIds, oldMembersIds, changedMembersIds, changedPercentages }) {
     return axios.patch(
-      `/api/froggo_teams/${id}`, decamelizeKeys({ name, newMembersIds, oldMembersIds, changedMembersIds }));
+      `/api/froggo_teams/${id}`,
+      decamelizeKeys({ name, newMembersIds, oldMembersIds, changedMembersIds, changedPercentages }),
+    );
   },
 
   [DELETE_FROGGO_TEAM](_, { id }) {

--- a/app/models/froggo_team_membership.rb
+++ b/app/models/froggo_team_membership.rb
@@ -27,6 +27,7 @@ end
 #  is_member_active       :boolean          default(TRUE)
 #  last_deactivation_date :datetime
 #  last_activation_date   :datetime
+#  assignment_percentage  :integer          default(100)
 #
 # Indexes
 #

--- a/app/models/froggo_team_membership.rb
+++ b/app/models/froggo_team_membership.rb
@@ -4,6 +4,10 @@ class FroggoTeamMembership < ApplicationRecord
   belongs_to :github_user
   belongs_to :froggo_team
 
+  validates :assignment_percentage, numericality: { only_integer: true,
+                                                    greater_than_or_equal_to: 1,
+                                                    less_than_or_equal_to: 100 }
+
   private
 
   def update_activation_date

--- a/db/data/20201006144402_add_value_to_assignment_percentage.rb
+++ b/db/data/20201006144402_add_value_to_assignment_percentage.rb
@@ -1,0 +1,7 @@
+class AddValueToAssignmentPercentage < ActiveRecord::Migration[6.0]
+  def up
+    FroggoTeamMembership.update_all(assignment_percentage: 100)
+  end
+
+  def down; end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20200923161151)
+DataMigrate::Data.define(version: 20201006144402)

--- a/db/migrate/20201006141955_add_assignment_percentage_to_froggo_team_memberships.rb
+++ b/db/migrate/20201006141955_add_assignment_percentage_to_froggo_team_memberships.rb
@@ -1,0 +1,10 @@
+class AddAssignmentPercentageToFroggoTeamMemberships < ActiveRecord::Migration[6.0]
+  def up
+    add_column :froggo_team_memberships, :assignment_percentage, :integer
+    change_column_default :froggo_team_memberships, :assignment_percentage, 100
+  end
+
+  def down
+    remove_column :froggo_team_memberships, :assignment_percentage
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_29_135252) do
+ActiveRecord::Schema.define(version: 2020_10_06_141955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2020_09_29_135252) do
     t.boolean "is_member_active", default: true
     t.datetime "last_deactivation_date"
     t.datetime "last_activation_date"
+    t.integer "assignment_percentage", default: 100
     t.index ["froggo_team_id"], name: "index_froggo_team_memberships_on_froggo_team_id"
     t.index ["github_user_id"], name: "index_froggo_team_memberships_on_github_user_id"
   end

--- a/spec/models/froggo_team_membership_spec.rb
+++ b/spec/models/froggo_team_membership_spec.rb
@@ -1,9 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe FroggoTeamMembership, type: :model do
+  subject(:membership) { described_class.new }
+
   let!(:user) { create(:github_user) }
   let!(:organization) { create(:organization) }
   let!(:team) { create(:froggo_team, organization: organization) }
+
+  describe "validations" do
+    it do
+      expect(membership).to validate_numericality_of(:assignment_percentage)
+        .only_integer.is_greater_than_or_equal_to(1).is_less_than_or_equal_to(100)
+    end
+  end
 
   describe 'relationships' do
     it { is_expected.to belong_to(:github_user) }


### PR DESCRIPTION
La idea de este PR es implementar que las personas que son miembros de un equipo de Froggo, se puedan asignar un % de asignación de PRs. Por ejemplo ... si estoy trabajando en un proyecto, y me gustaría que me envíen solo el 50% de los pr que les envían al resto de mis compañeros, lo puedo setear.
Para eso se agregó la columna assignment_percentage :) 