### PR TITLE
No teams message

### DIFF
--- a/app/javascript/components/organizations-dropdown.vue
+++ b/app/javascript/components/organizations-dropdown.vue
@@ -5,14 +5,17 @@
     :items="organizations"
     :default-index="defaultOrganizationIndex"
     @item-clicked="onItemClicked"
-  >
-  </clickable-dropdown>
+  />
 </template>
 
 <script>
 import ClickableDropdown from './clickable-dropdown';
 import { PROCESS_NEW_TEAM } from '../store/action-types';
-import { PROFILE_ORGANIZATION_SELECTED } from '../store/mutation-types';
+import {
+  PROFILE_ORGANIZATION_SELECTED,
+  PROFILE_TEAM_SELECTED,
+  PROFILE_PR_INFORMATION_RECEIVED,
+} from '../store/mutation-types';
 
 export default {
   props: {
@@ -59,6 +62,8 @@ export default {
       const organizationTeams = this.teams.filter(team => team.organization_id === organization.id);
       if (organizationTeams.length === 0) {
         this.$store.commit(PROFILE_ORGANIZATION_SELECTED, organization.id);
+        this.$store.commit(PROFILE_TEAM_SELECTED, { teamId: null, froggoTeam: false });
+        this.$store.commit(PROFILE_PR_INFORMATION_RECEIVED, { 'pull_requests_information': {} });
 
         return;
       }

--- a/app/javascript/components/profile/recommendations.vue
+++ b/app/javascript/components/profile/recommendations.vue
@@ -1,22 +1,33 @@
 <template>
-  <div class="profile-interactions">
-    <profile-relations
-      :being-fetched="fetchingRecommendations"
-      :recommendations="recommendations"
-    />
-    <div class="profile-recommendations">
-      <profile-recommendations-users
+  <div>
+    <div
+      class="profile-interactions"
+      v-if="selectedTeam"
+    >
+      <profile-relations
         :being-fetched="fetchingRecommendations"
         :recommendations="recommendations"
-        type="best"
-        :title="$i18n.t('message.profile.recommendedReviewers')"
       />
-      <profile-recommendations-users
-        :being-fetched="fetchingRecommendations"
-        :recommendations="recommendations"
-        type="worst"
-        :title="$i18n.t('message.profile.notRecommendedReviewers')"
-      />
+      <div class="profile-recommendations">
+        <profile-recommendations-users
+          :being-fetched="fetchingRecommendations"
+          :recommendations="recommendations"
+          type="best"
+          :title="$i18n.t('message.profile.recommendedReviewers')"
+        />
+        <profile-recommendations-users
+          :being-fetched="fetchingRecommendations"
+          :recommendations="recommendations"
+          type="worst"
+          :title="$i18n.t('message.profile.notRecommendedReviewers')"
+        />
+      </div>
+    </div>
+    <div
+      class="card__info"
+      v-else
+    >
+      {{ $i18n.t('message.profile.noTeamsInOrganization') }}
     </div>
   </div>
 </template>
@@ -30,6 +41,7 @@ export default {
   computed: mapState({
     recommendations: state => state.profile.recommendations,
     fetchingRecommendations: state => state.profile.fetchingRecommendations,
+    selectedTeam: state => state.profile.selectedTeamId,
   }),
   components: {
     ProfileRelations,

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -18,6 +18,7 @@ export default {
       organizationsDropdownTitle: 'Organizations',
       recommendedReviewers: 'You should assign your next PR to...',
       notRecommendedReviewers: 'Avoid assigning your next PR to...',
+      noTeamsInOrganization: 'You are not a member of any team in this organization',
       statistics: {
         obedientCount: 'Obeyed recommendations',
         indifferentCount: 'Ignored recommendations',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -18,6 +18,7 @@ export default {
       organizationsDropdownTitle: 'Organizaciones',
       recommendedReviewers: 'Deberías mandar tu próximo PR a...',
       notRecommendedReviewers: 'Evita mandar tu próximo PR a...',
+      noTeamsInOrganization: 'Aún no perteneces a un equipo en esta organización',
       statistics: {
         obedientCount: 'Recomendaciones seguidas',
         indifferentCount: 'Recomendaciones ignoradas',


### PR DESCRIPTION
Este PR es para agregar al perfil de froggo un mensaje cuando el usuario elija una organización en la cual aún no es miembro de ningún equipo.