### PR TITLE
Fix no teams message

### DIFF
--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -18,7 +18,7 @@ export default {
       organizationsDropdownTitle: 'Organizations',
       recommendedReviewers: 'You should assign your next PR to...',
       notRecommendedReviewers: 'Avoid assigning your next PR to...',
-      noTeamsInOrganization: 'You are not a member of any team in this organization',
+      noTeamsInOrganization: 'You are not member of any organization team so you have no recommendations',
       statistics: {
         obedientCount: 'Obeyed recommendations',
         indifferentCount: 'Ignored recommendations',
@@ -55,7 +55,7 @@ export default {
       successfullySavedChanges: 'Changes were successfully saved',
       successfullyCreatedTeam: 'Team was successfully created',
       percentageDropdownTitle: 'PRs assignation',
-      increasePercentageMessage: 'If you are going to increase the asignation %, remember to do it progressively',
+      increasePercentageMessage: 'If you are going to increase the assignation % remember to do it progressively',
     },
     prFeed: {
       noName: 'Unknown',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -18,7 +18,7 @@ export default {
       organizationsDropdownTitle: 'Organizaciones',
       recommendedReviewers: 'Deberías mandar tu próximo PR a...',
       notRecommendedReviewers: 'Evita mandar tu próximo PR a...',
-      noTeamsInOrganization: 'Aún no perteneces a un equipo en esta organización',
+      noTeamsInOrganization: 'No tienes recomendaciones dado que aún no perteneces a un equipo en esta organización',
       statistics: {
         obedientCount: 'Recomendaciones seguidas',
         indifferentCount: 'Recomendaciones ignoradas',
@@ -55,7 +55,7 @@ export default {
       successfullySavedChanges: 'Cambios guardados exitosamente',
       successfullyCreatedTeam: 'Equipo creado exitosamente',
       percentageDropdownTitle: 'Asignación de PRs',
-      increasePercentageMessage: 'Si vas a aumentar el % de asignación de PR, recuerda hacerlo en forma progresiva',
+      increasePercentageMessage: 'Si vas a aumentar el % de asignación de PRs recuerda hacerlo en forma progresiva',
     },
     prFeed: {
       noName: 'Desconocido',

--- a/app/views/github_users/_profile_card.html.erb
+++ b/app/views/github_users/_profile_card.html.erb
@@ -27,9 +27,6 @@
     </div>
   </div>
   <div class="profile__section">
-    <% if @teams.empty? %>
-      <%= t('messages.profile.no_recommendations') %>
-    <% end %>
     <profile-recommendations />
   </div>
   <div class="profile__section">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,7 +109,6 @@ en:
       your_score: Your score
       recommended_reviewers: We recommend you request a review from one of these persons
       not_recommended_reviewers: Avoid requesting reviews from these persons
-      no_recommendations: You don't belong to any organization so there are no recommendations for you
       give_permissions: Configure organizations
     froggoTeams:
       empty_title:  You don't have any Team

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -82,7 +82,6 @@ es-CL:
       your_score: Tu puntaje
       recommended_reviewers: Te recomendamos mandar tu próximo PR a alguna de estas personas
       not_recommended_reviewers: Evita mandarle otro PR a estas personas
-      no_recommendations: No tenemos recomendaciones para ti dado que no perteneces a ninguna organización
       give_permissions: Configurar organizaciones
     froggoTeams:
       empty_title: Aún no tienes equipos!


### PR DESCRIPTION
Este PR borra una doble verificación que se hacía para saber si el usuario no tiene teams y arregla los mensajes que se muestran.