### PR TITLE
feat(pull_requests/index.html.erb): added filters of top liked and by…

### DIFF
--- a/app/assets/stylesheets/app/card.scss
+++ b/app/assets/stylesheets/app/card.scss
@@ -179,6 +179,29 @@ $roboto: 'Roboto', sans-serif;
       margin-left: 20px;
     }
 
+    &__filter {
+      font-family: roboto, sans-serif;
+      display: flex;
+      flex-direction: row;
+      margin-left: 60px;
+
+      &__title {
+        flex: 1;
+        text-align: left;
+      }
+
+      &__separation {
+        margin-bottom: 20px;
+      }
+
+      &__input {
+        flex: 8;
+        text-align: left;
+        margin-bottom: 10px;
+
+      }
+    }
+
     &__background {
       background-color: $white;
       display: block;

--- a/app/commands/filter_pull_requests.rb
+++ b/app/commands/filter_pull_requests.rb
@@ -2,6 +2,10 @@ class FilterPullRequests < PowerTypes::Command.new(:all_pull_requests, :options)
   def perform
     filter(:project_name) { |pr| pr.by_repository(@options[:project_name]) }
     filter(:owner_name) { |pr| pr.by_owner(@options[:owner_name]) }
+    filter(:title) { |pr| pr.by_title(@options[:title]) }
+    filter(:start_date) { |pr| pr.by_start_date(@options[:start_date]) }
+    filter(:end_date) { |pr| pr.by_end_date(@options[:end_date]) }
+    filter(:top_liked) { |pr| pr.by_top_liked.limit(15) }
     pull_requests
   end
 

--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -6,10 +6,11 @@ class PullRequestsController < ApplicationController
     @organization_name = organization_name
     @pull_requests = PullRequest.by_organizations(
       [organization.id]
-    ).order(created_at: :desc)
+    )
     @pull_requests = FilterPullRequests.for(all_pull_requests: @pull_requests,
                                             options: filtering_params)
-    @pull_requests = @pull_requests.page(params[:page])
+    @pull_requests = @pull_requests.order(created_at: :desc)
+    @pull_requests = @pull_requests.page(params[:page]) unless params.has_key? :top_liked
     @serialized_pull_requests = ActiveModel::Serializer::CollectionSerializer.new(
       @pull_requests, each_serializer: PullRequestSerializer
     )
@@ -38,6 +39,6 @@ class PullRequestsController < ApplicationController
   end
 
   def filtering_params
-    params.permit(:project_name, :owner_name)
+    params.permit(:project_name, :owner_name, :start_date, :title, :end_date, :top_liked)
   end
 end

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -59,6 +59,7 @@ export default {
       prName: 'Pull Request',
       prAuthor: 'Author',
       prProject: 'Project',
+      prTitle: 'Title',
       prTime: 'Time',
       prDate: 'Date',
       prDescription: 'Description',
@@ -69,6 +70,8 @@ export default {
       prSee: 'See',
       prCreated: 'Created by',
       prThe: 'the',
+      prStartDate: 'Date From',
+      prEndDate: 'Date Until',
     },
     error: {
       unauthorized: 'Permission denied',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -59,6 +59,7 @@ export default {
       prName: 'Pull Request',
       prAuthor: 'Autor',
       prProject: 'Proyecto',
+      prTitle: 'Titulo',
       prTime: 'Hora',
       prDate: 'Fecha',
       prDescription: 'Descripción',
@@ -69,6 +70,8 @@ export default {
       prSee: 'Ver',
       prCreated: 'Creado por',
       prThe: 'el',
+      prStartDate: 'Fecha Desde',
+      prEndDate: 'Fecha Hasta',
     },
     error: {
       unauthorized: 'No tiene autorización para realizar esta acción',

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -22,11 +22,40 @@ class PullRequest < ApplicationRecord
   end
 
   scope :by_repository, ->(repository) do
-    joins(:repository).where("LOWER(repositories.name) LIKE LOWER(?)", "%#{repository}%")
+    if repository.present?
+      joins(:repository).where("LOWER(repositories.name) LIKE LOWER(?)", "%#{repository}%")
+    end
   end
 
   scope :by_owner, ->(owner) do
-    joins(:owner).where("LOWER(github_users.login) LIKE LOWER(?)", "%#{owner}%")
+    if owner.present?
+      joins(:owner).where("LOWER(github_users.login) LIKE LOWER(?)", "%#{owner}%")
+    end
+  end
+
+  scope :by_start_date, ->(date) do
+    if date.present?
+      joins(:owner).where("pull_requests.created_at >= ?", "%#{date}%")
+    end
+  end
+
+  scope :by_end_date, ->(date) do
+    if date.present?
+      joins(:owner).where("pull_requests.created_at <= ?", "%#{date}%")
+    end
+  end
+
+  scope :by_title, ->(title) do
+    if title.present?
+      joins(:owner).where("LOWER(pull_requests.title) LIKE LOWER(?)", "%#{title}%")
+    end
+  end
+
+  scope :by_top_liked, -> do
+    joins(:likes)
+      .select('pull_requests.*, count(likes) as like_count')
+      .group('pull_requests.id')
+      .order("like_count desc")
   end
 
   validates :gh_id, presence: true

--- a/app/serializers/pull_request_serializer.rb
+++ b/app/serializers/pull_request_serializer.rb
@@ -2,6 +2,8 @@ class PullRequestSerializer < ActiveModel::Serializer
   attributes :id, :title, :repository_name, :owner_id, :html_url, :likes, :created_at,
              :owner_name, :description, :commits, :owner_login
   def likes
+    return object.like_count if object.respond_to? :like_count
+
     object.likes.count
   end
 end

--- a/app/views/pull_requests/index.html.erb
+++ b/app/views/pull_requests/index.html.erb
@@ -6,23 +6,51 @@
         Feed
       </div>
       <form action="/organizations/<%= @organization_name %>/pull_requests">
-        <label for="project_name">Proyecto:</label>
-        <input type="text" id="project_name" name="project_name">
-        <input type="submit" value="Submit">
-      </form>
-      <form action="/organizations/<%= @organization_name %>/pull_requests">
-        <label for="owner_name">Autor :</label>
-        <input type="text" id="owner_name" name="owner_name">
-        <input type="submit" value="Submit">
+        <div class="card-pr__filter">
+          <div class="card-pr__filter__title">
+            <p class="card-pr__filter__separation">
+              <label for="project_name">{{ $t("message.prFeed.prProject") }}:</label>
+            </p>
+            <p class="card-pr__filter__separation">
+              <label for="owner_name">{{ $t("message.prFeed.prAuthor") }}:</label>
+            </p>
+            <p class="card-pr__filter__separation">
+              <label for="title">{{ $t("message.prFeed.prTitle") }}:</label>
+            </p>
+            <p class="card-pr__filter__separation">
+              <label for="top_liked">Top 15 Likes</label><br>
+            </p>
+            <p class="card-pr__filter__separation">
+              <label for="start_date">{{ $t("message.prFeed.prStartDate") }}:</label>
+            </p>
+            <p class="card-pr__filter__separation">
+              <label for="end_date">{{ $t("message.prFeed.prEndDate") }}:</label>
+            </p>
+          </div>
+
+          <div class="card-pr__filter__input">
+
+            <p><input type="text" id="project_name" name="project_name"></p>
+            <p><input type="text" id="owner_name" name="owner_name"></p>
+            <p><input type="text" id="title" name="title"></p>
+            <p><input type="checkbox" id="top_liked" name="top_liked" value="top_liked"></p>
+            <p><input type="date" id="start_date" name="start_date"></p>
+            <p><input type="date" id="end_date" name="end_date"></p>
+            <p><input type="submit" value="Search"></p>
+
+          </div>
+        </div>
       </form>
       <pr-feed
         :pull-requests="<%= @serialized_pull_requests.to_json %> | camelizeKeys"
         :likes-given="<%= @likes_given.to_json %> | camelizeKeys"
         organization-name="<%= @organization_name %>" >
       </pr-feed>
-      <div class="card-pr__pagination">
-        <%= paginate @pull_requests %>
-      </div>
+      <% if @pull_requests.respond_to? :total_pages %>
+        <div class="card-pr__pagination">
+          <%= paginate @pull_requests %>
+        </div>
+      <% end %>
     </div>
   </div>
   <%= render "partials/footer" %>


### PR DESCRIPTION
… date, also align filters

El feed se presentan todas las pull requests que hay en platanus. Esto claramente es un problema por las decenas que se hacen diarias y se dificulta la búsqueda de un PR en específico. Para esto se decidió hacer filtros.

Antes de esta PR, habían dos filtros de texto para las pull requests. El primero es según el nombre del proyecto y el segundo según el nombre del creador de la PR.

Ahora se agregan 4 nuevos filtros:
1) Uno de texto para filtrar por título de PR
2) Uno de Checkbox si quieres buscar las top 15 PR (con más likes)
3) Uno de Date, para escoger la fecha de inicio desde cuando quieres buscar PRs
4) Otro de Date, para escoger la fecha de fin hasta cuando quieres buscar PRs

Se ve de la siguiente forma los filtros:
<img width="337" alt="Screen Shot 2020-10-16 at 1 36 03 PM" src="https://user-images.githubusercontent.com/17711310/96285964-0bb7ee00-0fb6-11eb-986b-58d42e27eba3.png">

Y la página en general así:
<img width="1081" alt="Screen Shot 2020-10-16 at 1 36 09 PM" src="https://user-images.githubusercontent.com/17711310/96286000-1a9ea080-0fb6-11eb-819d-117c3d22b508.png">

(No soy tan fanático de la forma que se ven los filtros con respecto a toda la vista, por si tienes algún Tip!)
