### PR TITLE
design(index.html): better distribution

### DIFF
--- a/app/assets/stylesheets/app/card.scss
+++ b/app/assets/stylesheets/app/card.scss
@@ -183,23 +183,49 @@ $roboto: 'Roboto', sans-serif;
       font-family: roboto, sans-serif;
       display: flex;
       flex-direction: row;
-      margin-left: 60px;
-
-      &__title {
-        flex: 1;
-        text-align: left;
-      }
+      margin-left: 40px;
+      margin-right: 60px;
 
       &__separation {
-        margin-bottom: 20px;
+        margin-bottom: 22px;
       }
 
-      &__input {
-        flex: 8;
+      &-title {
+        flex: 1;
         text-align: left;
-        margin-bottom: 10px;
-
+        color: $secondary-color;
+        font-weight: bold;
+        margin-left: 20px;
       }
+
+      &-input {
+        flex: 3;
+        text-align: left;
+      }
+
+      &__button {
+        border-color: grayscale($color: #fff);
+        color: $secondary-color;
+        cursor: pointer;
+        float: left;
+        font-size: 13px;
+        font-weight: 500;
+        height: 28px;
+        line-height: 24px;
+        margin-right: 10px;
+        min-width: 91px;
+        padding: 2px 5px;
+        text-align: center;
+        text-decoration: none;
+        text-transform: uppercase;
+        vertical-align: middle;
+      }
+
+      &__box-button {
+        text-align: right;
+        margin-left: 60px;
+      }
+
     }
 
     &__background {

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -73,8 +73,8 @@ export default {
       prSee: 'See',
       prCreated: 'Created by',
       prThe: 'the',
-      prStartDate: 'Date From',
-      prEndDate: 'Date Until',
+      prStartDate: 'From',
+      prEndDate: 'Until',
     },
     error: {
       unauthorized: 'Permission denied',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -73,8 +73,8 @@ export default {
       prSee: 'Ver',
       prCreated: 'Creado por',
       prThe: 'el',
-      prStartDate: 'Fecha Desde',
-      prEndDate: 'Fecha Hasta',
+      prStartDate: 'Desde',
+      prEndDate: 'Hasta',
     },
     error: {
       unauthorized: 'No tiene autorización para realizar esta acción',

--- a/app/views/pull_requests/index.html.erb
+++ b/app/views/pull_requests/index.html.erb
@@ -5,21 +5,39 @@
       <div class="card-pr-title">
         Feed
       </div>
+
       <form action="/organizations/<%= @organization_name %>/pull_requests">
         <div class="card-pr__filter">
-          <div class="card-pr__filter__title">
+          <div class="card-pr__filter-title">
             <p class="card-pr__filter__separation">
               <label for="project_name">{{ $t("message.prFeed.prProject") }}:</label>
             </p>
             <p class="card-pr__filter__separation">
               <label for="owner_name">{{ $t("message.prFeed.prAuthor") }}:</label>
             </p>
+          </div>
+
+          <div class="card-pr__filter-input">
+
+            <p><input type="text" id="project_name" name="project_name"></p>
+            <p><input type="text" id="owner_name" name="owner_name"></p>
+          </div>
+
+          <div class="card-pr__filter-title">
             <p class="card-pr__filter__separation">
               <label for="title">{{ $t("message.prFeed.prTitle") }}:</label>
             </p>
             <p class="card-pr__filter__separation">
               <label for="top_liked">Top 15 Likes</label><br>
             </p>
+          </div>
+
+          <div class="card-pr__filter-input">
+            <p><input type="text" id="title" name="title"></p>
+            <p><input type="checkbox" id="top_liked" name="top_liked" value="top_liked"></p>
+          </div>
+
+          <div class="card-pr__filter-title">
             <p class="card-pr__filter__separation">
               <label for="start_date">{{ $t("message.prFeed.prStartDate") }}:</label>
             </p>
@@ -28,19 +46,18 @@
             </p>
           </div>
 
-          <div class="card-pr__filter__input">
+      
 
-            <p><input type="text" id="project_name" name="project_name"></p>
-            <p><input type="text" id="owner_name" name="owner_name"></p>
-            <p><input type="text" id="title" name="title"></p>
-            <p><input type="checkbox" id="top_liked" name="top_liked" value="top_liked"></p>
+          <div class="card-pr__filter-input">
             <p><input type="date" id="start_date" name="start_date"></p>
             <p><input type="date" id="end_date" name="end_date"></p>
-            <p><input type="submit" value="Search"></p>
-
+            <p class="card-pr__filter__box-button"><input type="submit" value="Search" class="card-pr__filter__button"></p>
           </div>
+
         </div>
       </form>
+
+
       <pr-feed
         :pull-requests="<%= @serialized_pull_requests.to_json %> | camelizeKeys"
         :likes-given="<%= @likes_given.to_json %> | camelizeKeys"


### PR DESCRIPTION
El feed se presentan todas las pull requests que hay en platanus. Esto claramente es un problema por las decenas que se hacen diarias y se dificulta la búsqueda de un PR en específico. Para esto se decidió hacer filtros.

Antes de esta PR, habían dos filtros de texto para las pull requests. El primero es según el nombre del proyecto y el segundo según el nombre del creador de la PR.

Son 6 filtros que se veían así:

![image](https://user-images.githubusercontent.com/17711310/96510582-1c759780-1234-11eb-9f0f-c1468a035dfe.png)


Y ahora se hicieron cambios para que se vieran así:

![image](https://user-images.githubusercontent.com/17711310/96510592-213a4b80-1234-11eb-9648-479fc4812467.png)


