### PR TITLE
feat(relations.vue): added information of other users on profile

### DIFF
--- a/app/javascript/components/profile/relations.vue
+++ b/app/javascript/components/profile/relations.vue
@@ -38,6 +38,7 @@
                 <img
                   class="profile-relations__picture"
                   :src="item.avatar_url"
+                  v-tooltip="getTooltipMessage(user, index)"
                 >
               </div>
             </a>
@@ -99,6 +100,20 @@ export default {
   },
   methods: {
     colorFromScore,
+    getTooltipMessage(user, index) {
+      if (!this.belongedTeam || index === 0) {
+        return user.login;
+      }
+
+      const userInfo = user.login.concat(' \n',
+        this.$t('message.organization.members.inactiveDays'),
+        this.inactiveDays[user.id],
+        ' \n',
+        this.$t('message.organization.members.score'),
+        this.colorScores[user.id]);
+
+      return userInfo;
+    },
   },
 };
 </script>


### PR DESCRIPTION
Actualmente se puede ver más información en la vista de organizaciones cuando uno se sitúa sobre una imagen de alguien del equipo (en este caso Andrés):
![image](https://user-images.githubusercontent.com/17711310/97185163-7f0feb80-177e-11eb-985b-d4964fa246f1.png)

Ahora se hizo lo mismo para el perfil que antes no se podía:
![image](https://user-images.githubusercontent.com/17711310/97185198-8931ea00-177e-11eb-83a8-24557aae62ab.png)
Como arriba de la Paula, Gabriel, etc