### PR TITLE
feat(relations.vue): added information of other users on profile

### DIFF
--- a/app/javascript/components/profile/relations.vue
+++ b/app/javascript/components/profile/relations.vue
@@ -38,6 +38,7 @@
                 <img
                   class="profile-relations__picture"
                   :src="item.avatar_url"
+                  v-tooltip="getTooltipMessage(item)"
                 >
               </div>
             </a>
@@ -99,6 +100,20 @@ export default {
   },
   methods: {
     colorFromScore,
+    getTooltipMessage(user) {
+      if (!this.belongedTeam) {
+        return user.login;
+      }
+
+      const userInfo = user.login.concat(' \n',
+        this.$t('message.organization.members.inactiveDays'),
+        this.inactiveDays[user.id],
+        ' \n',
+        this.$t('message.organization.members.score'),
+        this.colorScores[user.id]);
+
+      return userInfo;
+    },
   },
 };
 </script>


### PR DESCRIPTION
Actualmente se puede ver más información en la vista de organizaciones cuando uno se sitúa sobre una imagen de alguien del equipo (en este caso Andrés):
![97185163-7f0feb80-177e-11eb-985b-d4964fa246f1](https://user-images.githubusercontent.com/17711310/97222635-784c9d00-17ad-11eb-92cb-adb70a0e850d.png)

Se quiso hacer lo mismo para el perfil que antes no se podía y ahora quedó igual:
<img width="1127" alt="Screen Shot 2020-10-26 at 5 04 42 PM" src="https://user-images.githubusercontent.com/17711310/97222713-8dc1c700-17ad-11eb-84e9-2429a14aeae5.png">

