### PR TITLE
fix(organization-matrix-head.vue): approximated scores to the second decimal

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/ruby:2.7-node
+      - image: circleci/ruby:2.7-node@sha256:4ce1bfae2e1449c1a86acc00e85374ee0d2c1cfcd48d7c9935651d8a11180e99
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3

--- a/app/javascript/components/organization-matrix-head.vue
+++ b/app/javascript/components/organization-matrix-head.vue
@@ -74,13 +74,13 @@ export default {
       if (!this.belongedTeam || index === 0) {
         return user.login;
       }
-
+      const decimalApproximation = 2;
       const userInfo = user.login.concat(' \n',
         this.$t('message.organization.members.inactiveDays'),
         this.inactiveDays[user.id],
         ' \n',
         this.$t('message.organization.members.score'),
-        this.colorScores[user.id]);
+        Number(this.colorScores[user.id].toFixed(decimalApproximation)));
 
       return userInfo;
     },


### PR DESCRIPTION
Actualmente se puede ver más información en la vista de organizaciones cuando uno se sitúa sobre una imagen de alguien del equipo (en este caso Raimundo), pero el Puntaje se puede ver gigante con todos los floats:

<img width="1110" alt="Screen Shot 2020-10-28 at 11 39 25 AM" src="https://user-images.githubusercontent.com/17711310/97451674-bf07d780-1912-11eb-9a5e-f7df686bc77c.png">

Es por esto que aquí simplemente se aproxima al segundo decimal ese Puntaje