### PR TITLE
feat(profile-dropdowns): added option to default month, team, organiz

### DIFF
--- a/app/javascript/components/organizations-dropdown.vue
+++ b/app/javascript/components/organizations-dropdown.vue
@@ -3,7 +3,7 @@
     :body-title="dropdownTitle"
     :no-items-message="noOrganizationsMessage"
     :items="organizations"
-    :default-index="defaultOrganizationIndex"
+    :default-index="getCookie || 0"
     @item-clicked="onItemClicked"
   />
 </template>
@@ -52,11 +52,15 @@ export default {
 
       return 0;
     },
+    getCookie() {
+      return parseInt(localStorage.getItem('organizationCookieId'), 10);
+    },
   },
   methods: {
-    onItemClicked({ item }) {
+    onItemClicked({ item, index }) {
       this.selectOrganization(item);
       this.makeOrganizationDefault(item);
+      this.$emit('organization-clicked', index);
     },
     selectOrganization(organization) {
       const organizationTeams = this.teams.filter(team => team.organization_id === organization.id);

--- a/app/javascript/components/profile-dropdowns.vue
+++ b/app/javascript/components/profile-dropdowns.vue
@@ -5,20 +5,29 @@
         :github-login="githubLogin"
         :organizations="organizations"
         :teams="teams"
+        @organization-clicked="onOrganizationClick"
       />
     </div>
     <div class="profile-header__dropdowns">
       <teams-dropdown
         :github-login="githubLogin"
         :teams="selectedOrganizationTeams"
+        @team-clicked="onTeamClick"
       />
     </div>
     <div class="profile-header__dropdowns">
       <timespan-dropdown
         :github-login="githubLogin"
         :months-options="monthsOptions"
+        @month-clicked="onMonthClick"
       />
     </div>
+    <button
+      class="card-pr__button"
+      @click="defaultLocal()"
+    >
+      {{ $t("message.settings.defaultOption") }}
+    </button>
   </div>
 </template>
 
@@ -47,6 +56,13 @@ export default {
       required: true,
     },
   },
+  data() {
+    return {
+      selectedMonth: -1,
+      selectedOrganization: -1,
+      selectedTeam: -1,
+    };
+  },
   components: {
     OrganizationsDropdown,
     TeamsDropdown,
@@ -59,6 +75,31 @@ export default {
     ...mapState({
       selectedOrganizationId: state => state.profile.selectedOrganizationId,
     }),
+  },
+  methods: {
+    onMonthClick(index) {
+      this.selectedMonth = index;
+    },
+    onOrganizationClick(index) {
+      this.selectedOrganization = index;
+    },
+    onTeamClick(index) {
+      this.selectedTeam = index;
+    },
+    defaultLocal() {
+      if (this.selectedMonth > -1) {
+        localStorage.setItem('monthCookieId', this.selectedMonth);
+      }
+      if (this.selectedOrganization > -1) {
+        localStorage.setItem('organizationCookieId', this.selectedOrganization);
+        if (this.selectedTeam === -1) {
+          localStorage.setItem('teamCookieId', 0);
+        }
+      }
+      if (this.selectedTeam > -1) {
+        localStorage.setItem('teamCookieId', this.selectedTeam);
+      }
+    },
   },
 };
 </script>

--- a/app/javascript/components/teams-dropdown.vue
+++ b/app/javascript/components/teams-dropdown.vue
@@ -3,16 +3,14 @@
     :body-title="dropdownTitle"
     :no-items-message="noTeamsMessage"
     :items="teams"
-    :default-index="defaultTeamIndex"
+    :default-index="getCookie || 0"
     @item-clicked="onItemClicked"
-  >
-  </clickable-dropdown>
+  />
 </template>
 
 <script>
 import ClickableDropdown from './clickable-dropdown';
-import { PROCESS_NEW_TEAM } from '../store/action-types';
-import { UPDATE_DEFAULT_TEAM } from '../store/action-types';
+import { PROCESS_NEW_TEAM, UPDATE_DEFAULT_TEAM } from '../store/action-types';
 
 export default {
   props: {
@@ -21,8 +19,8 @@ export default {
     organization: Object,
     adminMode: {
       type: Boolean,
-      default: false
-    }
+      default: false,
+    },
   },
   data() {
     const dropdownTitle = this.adminMode ?
@@ -31,10 +29,11 @@ export default {
     const noTeamsMessage = this.adminMode ?
       this.$t('message.admin.noDefaultTeam') :
       this.$t('message.profile.noTeams');
+
     return {
       dropdownTitle,
       noTeamsMessage,
-    }
+    };
   },
   mounted() {
     if (!this.adminMode) {
@@ -66,15 +65,19 @@ export default {
 
       return 0;
     },
+    getCookie() {
+      return parseInt(localStorage.getItem('teamCookieId'), 10);
+    },
   },
   methods: {
-    onItemClicked({ item }) {
-      if (this.adminMode){
-        this.onDefaultTeamSelected(item)
+    onItemClicked({ index, item }) {
+      if (this.adminMode) {
+        this.onDefaultTeamSelected(item);
       } else {
         this.onTeamSelected(item);
-        this.makeTeamDefault(item)
+        this.makeTeamDefault(item);
       }
+      this.$emit('team-clicked', index);
     },
 
     onTeamSelected(team) {

--- a/app/javascript/components/timespan-dropdown.vue
+++ b/app/javascript/components/timespan-dropdown.vue
@@ -2,7 +2,7 @@
   <clickable-dropdown
     :body-title="dropdownTitle"
     :items="monthsOptions"
-    :default-index="3"
+    :default-index="getCookie || 0"
     @item-clicked="onItemClick"
   />
 </template>
@@ -33,8 +33,9 @@ export default {
     };
   },
   methods: {
-    onItemClick({ item }) {
+    onItemClick({ item, index }) {
       this.selectTimespan(item.limit);
+      this.$emit('month-clicked', index);
     },
     selectTimespan(limit) {
       this.$store.dispatch(COMPUTE_RECOMMENDATIONS, {
@@ -47,6 +48,11 @@ export default {
         githubUserLogin: this.githubLogin,
         monthLimit: limit,
       });
+    },
+  },
+  computed: {
+    getCookie() {
+      return parseInt(localStorage.getItem('monthCookieId'), 10);
     },
   },
   components: {

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -10,6 +10,7 @@ export default {
       error: 'There was an error',
       disablePublic: 'Disable public dashboard',
       enablePublic: 'Enable public dashboard',
+      defaultOption: 'Set Default',
     },
     profile: {
       noTeams: 'No teams',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -10,6 +10,7 @@ export default {
       error: 'Ocurrió un error',
       disablePublic: 'Deshabilitar dashboard público',
       enablePublic: 'Habilitar dashboard público',
+      defaultOption: 'Fijar Predeterminado',
     },
     profile: {
       noTeams: 'Sin equipos',


### PR DESCRIPTION
En la página principal de froto (el perfil), uno puede escoger por cuantos meses quiere ver, que equipo y que organización. Sin embargo los defaults se escogen por el admin de la organización. 

Ahora con localStorage cada usuario puede escoger personalizado sus defaults. Simplemente apretando el botón de "set default":

<img width="1222" alt="Screen Shot 2020-11-09 at 11 23 12 AM" src="https://user-images.githubusercontent.com/17711310/98553103-029d0280-227e-11eb-9f32-c96980341bb1.png">
