### PR TITLE
fix(card.css): change style of button

### DIFF
--- a/app/assets/stylesheets/app/card.scss
+++ b/app/assets/stylesheets/app/card.scss
@@ -390,6 +390,33 @@ $roboto: 'Roboto', sans-serif;
       vertical-align: middle;
     }
 
+    &__button-color {
+      background-color: $white;
+      color: $primary-color;
+      border: solid 2px $primary-color;
+      border-radius: 10px;
+      cursor: pointer;
+      display: table-cell;
+      float: right;
+      font-size: 13px;
+      font-weight: 500;
+      height: fit-content;
+      line-height: 30px;
+      margin-left: 5px;
+      margin-right: 0;
+      min-width: 55px;
+      padding: 2px 5px;
+      text-align: center;
+      margin-top: 3px;
+      text-decoration: none;
+      vertical-align: middle;
+    }
+
+    &__button-color:hover {
+      background-color: $primary-color;
+      color: $white;
+    }
+
     &__orientation {
       flex-direction: row;
       object-fit: cover;

--- a/app/javascript/components/profile-dropdowns.vue
+++ b/app/javascript/components/profile-dropdowns.vue
@@ -23,7 +23,7 @@
       />
     </div>
     <button
-      class="card-pr__button"
+      class="card-pr__button-color"
       @click="defaultLocal()"
     >
       {{ $t("message.settings.defaultOption") }}

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -10,7 +10,7 @@ export default {
       error: 'Ocurrió un error',
       disablePublic: 'Deshabilitar dashboard público',
       enablePublic: 'Habilitar dashboard público',
-      defaultOption: 'Fijar Predeterminado',
+      defaultOption: 'Predeterminar',
     },
     profile: {
       noTeams: 'Sin equipos',


### PR DESCRIPTION
En el botón Predeterminar del perfil:

<img width="1215" alt="Screen Shot 2020-11-09 at 12 59 05 PM" src="https://user-images.githubusercontent.com/17711310/98564657-624dda80-228b-11eb-9c10-271e2978c402.png">


Se hicieron 3 cambios:

1.- Ver cómo se ve solo si dice “Predeterminar”.
2.- Que al poner el mouse encima el fondo blanco pase a ser verde y la letra blanca para que se note que lo vas a apretar
3.- Sacarle el margin-right y dejarlo en 0 (al botón)

Quedando con hover así:

<img width="1239" alt="Screen Shot 2020-11-09 at 1 00 25 PM" src="https://user-images.githubusercontent.com/17711310/98564845-a5a84900-228b-11eb-9220-73113d4165c6.png">
