### PR TITLE
fix(profile-dropdowns.vue): fix the connection dropdowns and chart

### DIFF
--- a/app/javascript/components/profile-dropdowns.vue
+++ b/app/javascript/components/profile-dropdowns.vue
@@ -36,8 +36,10 @@ import { mapState } from 'vuex';
 import OrganizationsDropdown from './organizations-dropdown';
 import TeamsDropdown from './teams-dropdown';
 import TimespanDropdown from './timespan-dropdown';
+import showMessageMixin from '../mixins/showMessageMixin';
 
 export default {
+  mixins: [showMessageMixin],
   props: {
     teams: {
       type: Array,
@@ -61,6 +63,8 @@ export default {
       selectedMonth: -1,
       selectedOrganization: -1,
       selectedTeam: -1,
+      selectOrganizationId: -1,
+      selectedTeamId: -1,
     };
   },
   components: {
@@ -80,25 +84,40 @@ export default {
     onMonthClick(index) {
       this.selectedMonth = index;
     },
-    onOrganizationClick(index) {
+    onOrganizationClick(index, id) {
       this.selectedOrganization = index;
+      this.selectOrganizationId = id;
     },
-    onTeamClick(index) {
+    onTeamClick(index, id) {
       this.selectedTeam = index;
+      this.selectedTeamId = id;
     },
     defaultLocal() {
       if (this.selectedMonth > -1) {
-        localStorage.setItem('monthCookieId', this.selectedMonth);
+        localStorage.setItem('personalMonthIndex', this.selectedMonth);
       }
+      const mapUserToDefaultTeam =
+        localStorage.mapUserToDefaultTeam ?
+          JSON.parse(localStorage.mapUserToDefaultTeam) :
+          {};
       if (this.selectedOrganization > -1) {
-        localStorage.setItem('organizationCookieId', this.selectedOrganization);
+        localStorage.setItem('personalOrgIndex', this.selectedOrganization);
+        const mapUserToDefaultOrg =
+          localStorage.mapUserToDefaultOrg ?
+            JSON.parse(localStorage.mapUserToDefaultOrg) :
+            {};
+        mapUserToDefaultOrg[this.githubLogin] = this.selectOrganizationId;
+        localStorage.mapUserToDefaultOrg = JSON.stringify(mapUserToDefaultOrg);
         if (this.selectedTeam === -1) {
-          localStorage.setItem('teamCookieId', 0);
+          localStorage.setItem('personalTeamIndex', 0);
         }
       }
       if (this.selectedTeam > -1) {
-        localStorage.setItem('teamCookieId', this.selectedTeam);
+        localStorage.setItem('personalTeamIndex', this.selectedTeam);
+        mapUserToDefaultTeam[this.githubLogin] = this.selectedTeamId;
+        localStorage.mapUserToDefaultTeam = JSON.stringify(mapUserToDefaultTeam);
       }
+      this.showMessage(this.$t('message.settings.successfullyDefaulted'));
     },
   },
 };

--- a/app/javascript/components/teams-dropdown.vue
+++ b/app/javascript/components/teams-dropdown.vue
@@ -48,25 +48,20 @@ export default {
     defaultTeamIndex() {
       if (this.adminMode) {
         const defaultTeamId = this.organization.default_team_id;
+
         return defaultTeamId ? this.teams.findIndex(team => team.id === defaultTeamId) : -1;
       }
-      if (!localStorage.mapUserToDefaultTeam) {
-        return 0;
-      }
+      if (!localStorage.mapUserToDefaultTeam) return 0;
       const mapUserToDefaultTeam = JSON.parse(localStorage.mapUserToDefaultTeam);
-      if (!mapUserToDefaultTeam.hasOwnProperty(this.githubLogin)) {
-        return 0;
-      }
+      if (!mapUserToDefaultTeam.hasOwnProperty(this.githubLogin)) return 0;
       const teamId = mapUserToDefaultTeam[this.githubLogin];
       const index = this.teams.findIndex(team => team.id === teamId);
-      if (index >= 0) {
-        return index;
-      }
+      if (index >= 0) return index;
 
       return 0;
     },
     getCookie() {
-      return parseInt(localStorage.getItem('teamCookieId'), 10);
+      return parseInt(localStorage.getItem('personalTeamIndex'), 10);
     },
   },
   methods: {
@@ -77,15 +72,18 @@ export default {
         this.onTeamSelected(item);
         this.makeTeamDefault(item);
       }
-      this.$emit('team-clicked', index);
+      this.$emit('team-clicked', index, item.id);
     },
 
     onTeamSelected(team) {
+      const monthPersonalLimit =
+        (parseInt(localStorage.getItem('personalMonthIndex'), 10) * this.monthSeparationDropdown) || 1;
       this.$store.dispatch(PROCESS_NEW_TEAM, {
         teamId: team.id,
         organizationId: team.organization_id,
         githubUserLogin: this.githubLogin,
         froggoTeam: team.froggo_team,
+        monthLimit: monthPersonalLimit,
       });
     },
 

--- a/app/javascript/components/timespan-dropdown.vue
+++ b/app/javascript/components/timespan-dropdown.vue
@@ -52,7 +52,7 @@ export default {
   },
   computed: {
     getCookie() {
-      return parseInt(localStorage.getItem('monthCookieId'), 10);
+      return parseInt(localStorage.getItem('personalMonthIndex'), 10);
     },
   },
   components: {

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -11,6 +11,7 @@ export default {
       disablePublic: 'Disable public dashboard',
       enablePublic: 'Enable public dashboard',
       defaultOption: 'Set Default',
+      successfullyDefaulted: 'Defaulted attributes successfully',
     },
     profile: {
       noTeams: 'No teams',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -11,6 +11,7 @@ export default {
       disablePublic: 'Deshabilitar dashboard público',
       enablePublic: 'Habilitar dashboard público',
       defaultOption: 'Predeterminar',
+      successfullyDefaulted: 'Atributos predeterminados exitosamente',
     },
     profile: {
       noTeams: 'Sin equipos',

--- a/app/javascript/store/modules/profile/actions.js
+++ b/app/javascript/store/modules/profile/actions.js
@@ -21,14 +21,14 @@ import {
 
 export default {
   [PROCESS_NEW_TEAM](
-    { commit, dispatch }, { teamId, organizationId, githubUserLogin, froggoTeam }) {
+    { commit, dispatch }, { teamId, organizationId, githubUserLogin, froggoTeam, monthLimit }) {
     commit(PROFILE_ORGANIZATION_SELECTED, organizationId);
     commit(PROFILE_TEAM_SELECTED, { teamId, froggoTeam });
     dispatch(COMPUTE_STATISTICS, {
       organizationId,
       githubUserLogin,
     });
-    dispatch(COMPUTE_RECOMMENDATIONS, { teamId, githubUserLogin, froggoTeam });
+    dispatch(COMPUTE_RECOMMENDATIONS, { teamId, githubUserLogin, froggoTeam, monthLimit });
     dispatch(COMPUTE_PROFILE_PR_INFORMATION, { githubUserLogin });
   },
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -198,9 +198,9 @@ ActiveRecord::Schema.define(version: 2020_10_06_141955) do
     t.bigint "repository_id"
     t.integer "owner_id"
     t.integer "merged_by_id"
+    t.datetime "last_change"
     t.string "description"
     t.integer "commits"
-    t.datetime "last_change"
     t.index ["repository_id"], name: "index_pull_requests_on_repository_id"
   end
 


### PR DESCRIPTION
Ahora con localStorage cada usuario puede escoger personalizado sus defaults. Simplemente apretando el botón de "set default":

<img width="1421" alt="Screen Shot 2020-11-18 at 6 31 04 PM" src="https://user-images.githubusercontent.com/17711310/99590577-46091680-29cc-11eb-9664-92cd55c53adb.png">


No obstante, no estaban bien conectados los dropdowns con la barra de personas que se muestran abajo. Se arregló esto siguiendo la lógica ids para las personas y usando localStorage con índex para el dropdown.

Por último, se agregó un aviso al predeterminar un equipo.