### PR TITLE
fix(organizations-dropdowns.vue): fixed teams default profile

### DIFF
--- a/app/javascript/components/organizations-dropdown.vue
+++ b/app/javascript/components/organizations-dropdown.vue
@@ -74,8 +74,16 @@ export default {
       }
       const mapUserToDefaultTeam = localStorage.mapUserToDefaultTeam ?
         JSON.parse(localStorage.mapUserToDefaultTeam) : {};
-      const defaultTeam = this.organizationHasDefaultTeam(organization) ?
-        this.teams.filter(team => team.id === mapUserToDefaultTeam[this.githubLogin])[0] : organizationTeams[0];
+      const personalDefaultTeamId = mapUserToDefaultTeam[this.githubLogin] ?
+        mapUserToDefaultTeam[this.githubLogin] : 0;
+      let defaultTeam;
+      if (personalDefaultTeamId) {
+        defaultTeam = this.teams.find(team => team.id === personalDefaultTeamId);
+      } else if (this.organizationHasDefaultTeam(organization)) {
+        defaultTeam = this.teams.filter(team => team.id === mapUserToDefaultTeam[this.githubLogin])[0];
+      } else {
+        defaultTeam = organizationTeams[0];
+      }
       const monthPersonalLimit =
         (parseInt(localStorage.getItem('personalMonthIndex'), 10) * this.monthSeparationDropdown) || 1;
       this.$store.dispatch(PROCESS_NEW_TEAM, {

--- a/app/javascript/components/teams-dropdown.vue
+++ b/app/javascript/components/teams-dropdown.vue
@@ -33,15 +33,19 @@ export default {
     return {
       dropdownTitle,
       noTeamsMessage,
+      monthSeparationDropdown: 3,
     };
   },
-  mounted() {
-    if (!this.adminMode) {
-      const selectedTeam = this.teams[this.defaultTeamIndex];
-      if (selectedTeam) {
-        this.onTeamSelected(selectedTeam);
+
+  watch: {
+    defaultTeamIndex(newValue) {
+      if (!this.adminMode) {
+        const selectedTeam = this.teams[newValue];
+        if (selectedTeam) {
+          this.onTeamSelected(selectedTeam);
+        }
       }
-    }
+    },
   },
 
   computed: {


### PR DESCRIPTION
Ahora con localStorage cada usuario puede escoger personalizado sus defaults. Simplemente apretando el botón de "set default":

![image](https://user-images.githubusercontent.com/17711310/100481752-e7325400-30d3-11eb-8cff-e5e2b375d81c.png)

No obstante, no estaba bien conectados los dropdowns del equipo/team con la barra de personas que se muestran abajo. Se arregló esto siguiendo la lógica ya que se enviaba siempre el equipo por default de la organización y no la personal.

Aparte se hizo un watch() en team-dropdowns.vue en vez de mounted porque la información de selectedOrganizationTeams manda más de una vez 