### PR TITLE
feat(hover-tags): add tags to hover in relation table

### DIFF
--- a/app/commands/get_review_recommendations.rb
+++ b/app/commands/get_review_recommendations.rb
@@ -32,8 +32,10 @@ class GetReviewRecommendations < PowerTypes::Command.new(:github_user_id, :other
   def other_users_with_score
     @other_users_with_score ||= GithubUser.where(id: @other_users_ids).map do |user|
                                   user.as_json.with_indifferent_access.merge(
-                                    score: color_scores[user.id]
+                                    score: color_scores[user.id],
+                                    tags: user.tags.as_json
                                   )
+
                                 end.sort_by { |user| user[:score] }
   end
 

--- a/app/javascript/components/profile/relations.vue
+++ b/app/javascript/components/profile/relations.vue
@@ -102,7 +102,10 @@ export default {
     colorFromScore,
     getTooltipMessage(user) {
       if (!this.belongedTeam) {
-        return user.login;
+        const tagsText = user.tags.map(t => t.name).join('\n');
+        const text = `${user.login}\n tags: \n${user.tags.length ? tagsText : 'Aún no tengo tags'}`;
+
+        return text;
       }
 
       const userInfo = user.login.concat(' \n',


### PR DESCRIPTION
### Contexto
Se quiere poder visualizar los tags de los usuarios en la barra de relaciones haciendo hover sobre las caras.

### Qué se está haciendo
Se agregan los tags al computar GetReviewRecommendations, además se utilizan para agregarlos al texto del hover.

#### En particular hay que revisar