### PR TITLE
fix(description-validator): delete description validator

### DIFF
--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -17,9 +17,9 @@ class GithubUser < ApplicationRecord
 
   validates :gh_id, presence: true
   validates :login, presence: true
+  validates :description, length: { maximum: 255 }
 
   scope :all_except, ->(user) { where.not(id: user) }
-  validates :description, length: { maximum: 255 }
 
   def get_froggo_teams_for_organization(organization)
     froggo_teams.filter { |team| team[:organization_id] == organization.id }

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -17,9 +17,9 @@ class GithubUser < ApplicationRecord
 
   validates :gh_id, presence: true
   validates :login, presence: true
-  validates :description, length: { in: 0..255 }
 
   scope :all_except, ->(user) { where.not(id: user) }
+  validates :description, length: { maximum: 255 }
 
   def get_froggo_teams_for_organization(organization)
     froggo_teams.filter { |team| team[:organization_id] == organization.id }


### PR DESCRIPTION
### Contexto
Se quiere que la descripción en el usuario sea opcional.

### Qué se está haciendo
Se cambia la validación que permitía que la descripción fuese un string de 0 a 255 caracteres, por una que nos pide que sea sólo de máximo 255 caracteres, para poder permitir que la descripción sea opcional.

#### En particular hay que revisar
