### PR TITLE
fix(github): add custom to_json method to avoid ascii bug

### DIFF
--- a/app/values/github_session.rb
+++ b/app/values/github_session.rb
@@ -88,6 +88,10 @@ class GithubSession
     @session.permanent[froggo_path_key] = _path
   end
 
+  def to_json(*_)
+    { user: user }.to_json
+  end
+
   private
 
   def froggo_path_key


### PR DESCRIPTION
# Contexto
En staging y producción, repentinamente, la plataforma respondía error 500 a varios usuarios.

Debuggeando en local con uno de los usuarios afectados, nos dimos cuenta que tenía que ver con la serialización muy grande de un objeto del cuál solo se necesitaba un atributo.

# En esta PR
Se soluciona momentariamente el problema con un `to_json` custom en el objeto involucrado.