### PR TITLE
Pending pr

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "env": {
-    "es6": true
+    "es6": true,
+    "jest": true
   },
   "parserOptions": {
     "ecmaVersion": 2018,

--- a/app/assets/stylesheets/app/profile.scss
+++ b/app/assets/stylesheets/app/profile.scss
@@ -273,6 +273,34 @@
   padding: 40px;
 }
 
+.profile-prs {
+  margin-top: .75rem;
+  margin-bottom: .75rem;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: center;
+}
+
+.pr-to-assign {
+  text-align: justify;
+  margin: .75rem;
+  padding: .75rem;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+  flex-direction: column;
+  border: 1px solid rgba($primary-color, .5);
+  font-size: 1rem;
+  line-height: 1.5rem;
+  max-width: 280px;
+
+  &__title {
+    font-weight: 800;
+  }
+}
+
 .centered {
   text-align: center;
 }

--- a/app/controllers/github_users_controller.rb
+++ b/app/controllers/github_users_controller.rb
@@ -7,6 +7,7 @@ class GithubUsersController < ApplicationController
     @organizations = @github_user.organizations
     @user_tags = @github_user.tags
     @tags = Tag.all
+    @open_prs = open_prs(github_user)
   end
 
   # GET /me
@@ -33,5 +34,9 @@ class GithubUsersController < ApplicationController
     end
     gh_teams.concat(froggo_teams)
             .sort_by { |team| team[:name].downcase }
+  end
+
+  def open_prs(github_user)
+    PullRequest.by_owner(github_user.login).where(pr_state: 'open')
   end
 end

--- a/app/javascript/components/pending-pr.vue
+++ b/app/javascript/components/pending-pr.vue
@@ -1,0 +1,52 @@
+<template>
+  <div class="pr-to-assign">
+    <div
+      v-if="!recommendations"
+      class="loading-icon"
+    />
+    <div v-else>
+      <h4>
+        Se ha detectado un PR tuyo con el nombre:
+      </h4>
+      <h3 class="pr-to-assign__title">
+        #{{ pr }}
+      </h3>
+      <div>
+        <select>
+          <option
+            v-for="user in users()"
+            :value="user.id"
+            :key="user.id"
+          >
+            {{ user.login }}
+          </option>
+        </select>
+        <button class="card-pr__button-color">
+          ASIGNAR!
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+export default {
+  computed: mapState({
+    recommendations: state => state.profile.recommendations,
+    fetchingRecommendations: state => state.profile.fetchingRecommendations,
+  }),
+  props: {
+    pr: {
+      type: String,
+      required: true,
+    },
+  },
+  methods: {
+    users() {
+      return this.recommendations.all;
+    },
+  },
+};
+</script>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -22,6 +22,7 @@ import SyncOrganizationButton from '../components/sync-organization-button.vue';
 import DashboardSyncingIcon from '../components/dashboard-syncing-icon.vue';
 import PublicDashboardCarousel from '../components/public-dashboard/carousel.vue';
 import ProfileDropdowns from '../components/profile-dropdowns.vue';
+import PendingPr from '../components/pending-pr.vue';
 import ProfileRecommendations from '../components/profile/recommendations.vue';
 import ProfileStatistics from '../components/profile/statistics.vue';
 import PrFeed from '../components/pr-feed.vue';
@@ -66,6 +67,7 @@ document.addEventListener('DOMContentLoaded', () => {
   Vue.component('dashboard-syncing-icon', DashboardSyncingIcon);
   Vue.component('public-dashboard-carousel', PublicDashboardCarousel);
   Vue.component('profile-dropdowns', ProfileDropdowns);
+  Vue.component('pending-pr', PendingPr);
   Vue.component('profile-recommendations', ProfileRecommendations);
   Vue.component('profile-statistics', ProfileStatistics);
   Vue.component('pr-feed', PrFeed);

--- a/app/javascript/spec/components/pending-pr.spec.js
+++ b/app/javascript/spec/components/pending-pr.spec.js
@@ -1,0 +1,27 @@
+import { shallowMount } from '@vue/test-utils';
+
+import pendingPr from '../../components/pending-pr.vue';
+
+describe('PendingPR', () => {
+  const mockStore = {
+    state: {
+      profile: {
+        recommendations: { all: ['user_1', 'user_2', 'user_3'] },
+        fetchingRecommendations: false,
+      },
+    },
+  };
+  describe('User has 1 pending PR', () => {
+    it('Renders Title of Pending PR', () => {
+      const wrapper = shallowMount(pendingPr, {
+        propsData: {
+          pr: 'Test PR',
+        },
+        mocks: {
+          $store: mockStore,
+        },
+      });
+      expect(wrapper.html()).toContain('Test PR');
+    });
+  });
+});

--- a/app/views/github_users/_profile_card.html.erb
+++ b/app/views/github_users/_profile_card.html.erb
@@ -39,6 +39,13 @@
         />
       </div>
     </div>
+  <div class="profile-prs">
+    <% @open_prs.each do |pr| %>
+        <pending-pr
+          pr="<%= pr.title %>"
+        ></pending-pr>
+    <% end %>
+  </div>
   <div class="profile__section">
     <profile-recommendations />
   </div>

--- a/spec/controllers/github_users_controller_spec.rb
+++ b/spec/controllers/github_users_controller_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe GithubUsersController, type: :controller do
+  let(:user) { create(:github_user, login: "user_login") }
+  let(:platanus_org) { create(:organization, login: "platanus", members: [user]) }
+  let(:github_session) { instance_double("GithubSession") }
+
+  before do
+    allow(github_session).to receive(:token).and_return("token")
+    allow(github_session).to receive(:organizations).and_return(
+      [{ id: platanus_org.gh_id, role: "member" }]
+    )
+    allow(github_session).to receive(:user).and_return(user)
+    allow(controller).to receive(:github_session).and_return(github_session)
+    allow(controller).to receive(:authenticate_github_user).and_return(true)
+  end
+
+  describe '#GET /me' do
+    it 'returns redirect status' do
+      get :me, params: { github_user: user, github_session: github_session }
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+
+  describe '#GET /users/:id' do
+    it 'returns success status' do
+      get :show, params: { id: user.id, github_session: github_session }
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
## Contexto
Froggo es un proyecto interno para hacer lo más surtida posible la corrección de *pull requests* (PR's). Creemos que los PR's son una fuerte herramienta de transmisión de conocimiento de desarrollo y formas de abordar los problemas.

La aplicación tiene una grilla por organizaciones donde se puede ver todos los PR's enviados históricamente entre personas, y posee una vista personal donde se recomienda a quiénes mandar el siguiente PR y a quiénes evitar (recomendador).

La idea es potenciar la vista personal para que los desarrolladores solo deban ingresar a esta única vista.

## Objetivo

Ha sido mencionado varias veces que sería cómodo poder asignar un PR desde Froggo directamente. Esto evitaría estar saltando de una página a otra para asignar un PR. En cambio permitiría simplificar el flujo.

## Qué se está haciendo

Se obtienen los pull requests (abiertos) enviados por el usuario logeado en _github_users_controller.rb_ , y se le pasan estos a __profile_card.html.erb_  usando _@pulls_. 
Se crea componente _pending-pr.vue_ que muestra el titulo de un PR abierto y muestra en un _select_ los nombres de los integrantes de la organización (No sucede nada al seleccionar alguno).

## Revisar 
- Los test
- Que se muestre la componente si hay PR abierto