### PR TITLE
Team tags table style

### DIFF
--- a/app/assets/stylesheets/app/profile.scss
+++ b/app/assets/stylesheets/app/profile.scss
@@ -309,12 +309,19 @@
   &__column-title-center {
     font-weight: normal;
     text-align: center;
+    width: 25%;
+  }
+
+  &__column-title-color {
+    font-weight: normal;
+    text-align: center;
+    width: 20%;
   }
 
   &__column-title-tags {
     font-weight: normal;
     text-align: center;
-    width: 35%;
+    width: 30%;
   }
 
   &__input-user {

--- a/app/assets/stylesheets/app/profile.scss
+++ b/app/assets/stylesheets/app/profile.scss
@@ -272,8 +272,8 @@
 
 .profile-team-tags-table {
   border: 1px solid $gray;
-  flex: 1;
   max-height: 500px;
+  min-height: 300px;
   overflow-y: auto;
   width: 100%;
 
@@ -370,8 +370,10 @@
   &__description {
     align-items: center;
     color: $primary;
-    display: flex;
+    overflow: auto;
+    padding: .25rem .5rem;
     text-decoration: none;
+    height: 56px;
   }
 
   &__color-badge {

--- a/app/assets/stylesheets/app/select.scss
+++ b/app/assets/stylesheets/app/select.scss
@@ -72,13 +72,6 @@
   &__body {
     max-height: 300px;
     overflow-y: scroll;
-
-    &--color {
-      display: flex;
-      justify-content: center;
-      min-width: 200px;
-      overflow-x: scroll;
-    }
   }
 
   &-body__title {
@@ -89,6 +82,10 @@
     color: $primary;
     padding: 15px 42px 15px 18px;
     text-align: left;
+  }
+
+  &-body__all-option-center {
+    text-align: center;
   }
 
   &__option {
@@ -129,7 +126,6 @@
 
   &__color-badge {
     border-radius: 50%;
-    flex: 1;
     height: 20px;
     margin-right: auto;
     margin-left: auto;

--- a/app/javascript/components/clickable-dropdown/index.vue
+++ b/app/javascript/components/clickable-dropdown/index.vue
@@ -36,7 +36,7 @@
     </div>
     <div
       slot="body"
-      :class="colorMode? 'select__body--color' : 'select__body'"
+      class="select__body"
     >
       <div
         v-if="bodyTitle"
@@ -47,6 +47,7 @@
       <div
         v-if="allOption"
         class="select-body__title"
+        :class="colorMode && 'select-body__all-option-center'"
         @click="itemClicked({ index: -1 })"
       >
         {{ allOption }}
@@ -59,8 +60,11 @@
       >
         <div
           v-if="colorMode"
-          :class="`select__color-badge select__color-badge--${item.name}`"
-        />
+        >
+          <div
+            :class="`select__color-badge select__color-badge--${item.name}`"
+          />
+        </div>
         <div v-else>
           {{ item.name ? item.name : item.login }}
         </div>

--- a/app/javascript/components/profile/team-tags-container.vue
+++ b/app/javascript/components/profile/team-tags-container.vue
@@ -4,8 +4,12 @@
     class="profile-team-tags-container"
     v-if="selectedTeam"
   >
+    <div
+      v-if="fetchingRecommendations || !recommendations"
+      class="loading-icon"
+    />
     <team-tags-table
-      :being-fetched="fetchingRecommendations"
+      v-else
       :team="recommendations && recommendations.all"
       :tags="tags"
     />

--- a/app/javascript/components/profile/team-tags-table.vue
+++ b/app/javascript/components/profile/team-tags-table.vue
@@ -20,7 +20,7 @@
               @input="userFilter= $event.target.value.toLowerCase().trim()"
             >
           </th>
-          <th class="profile-team-tags-table__column-title-center ">
+          <th class="profile-team-tags-table__column-title-color ">
             {{ $i18n.t('message.profile.tagsTable.color') }}
             <clickable-dropdown
               :no-items-message="$i18n.t('message.profile.tagsTable.dropdownAll')"
@@ -28,6 +28,7 @@
               :default-index="-1"
               :center-mode="true"
               :color-mode="true"
+              :full-width-mode="true"
               @item-clicked="onColorClicked"
             />
           </th>

--- a/app/javascript/components/profile/team-tags-table.vue
+++ b/app/javascript/components/profile/team-tags-table.vue
@@ -1,11 +1,6 @@
 <template>
   <div class="profile-team-tags-table">
-    <div
-      v-if="beingFetched || !team"
-      class="loading-icon"
-    />
     <table
-      v-else
       class="profile-team-tags-table__table"
     >
       <thead class="profile-team-tags-table__header">
@@ -26,6 +21,7 @@
               :no-items-message="$i18n.t('message.profile.tagsTable.dropdownAll')"
               :items="colorOptions"
               :default-index="-1"
+              :all-option="$i18n.t('message.profile.tagsTable.dropdownAll')"
               :center-mode="true"
               :color-mode="true"
               :full-width-mode="true"
@@ -42,6 +38,7 @@
               :center-mode="true"
               :full-width-mode="true"
               @item-clicked="onTagClicked"
+              ref="dropdownTags"
             />
           </th>
           <th class="profile-team-tags-table__column-title-center ">
@@ -49,7 +46,9 @@
           </th>
         </tr>
       </thead>
-      <tbody class="profile-team-tags-table__body">
+      <tbody
+        class="profile-team-tags-table__body"
+      >
         <tr
           v-for="(user, index) in filteredTeam"
           :key="user.id"
@@ -75,13 +74,18 @@
             />
           </td>
           <td>
-            <team-tags
-              :tags="user.tags"
-              :index="index"
-            />
+            <div :ref="`tags${user.id}`">
+              <team-tags
+                :tags="user.tags"
+                :index="index"
+              />
+            </div>
           </td>
-          <td>
-            <div class="profile-team-tags-table__description">
+          <td class="profile-team-table ">
+            <div
+              class="profile-team-tags-table__description"
+              :style="{ height: `max(${rowHeight(user.id)}px, 56px)`}"
+            >
               {{ user.description }}
             </div>
           </td>
@@ -107,17 +111,22 @@ export default {
       selectedColor: null,
       selectedTag: null,
       userFilter: '',
+      maxRowHeight: {},
     };
   },
   components: { teamTags, ClickableDropdown },
+  mounted() {
+    const newMaxRowHeight = {};
+    this.team.forEach((user) => {
+      const userTags = this.$refs[`tags${user.id}`][0];
+      newMaxRowHeight[user.id.toString()] = userTags && userTags.clientHeight;
+    });
+    this.maxRowHeight = newMaxRowHeight;
+  },
   props: {
     team: {
       type: Array,
       default: () => [],
-    },
-    beingFetched: {
-      type: Boolean,
-      default: true,
     },
     tags: {
       type: Array,
@@ -136,6 +145,9 @@ export default {
         this.selectedTag = this.tags[event.index].name;
       }
     },
+    rowHeight(userId) {
+      return this.maxRowHeight[userId.toString()];
+    },
   },
   computed: {
     tagsIds() {
@@ -146,7 +158,6 @@ export default {
     },
     filteredTeam() {
       let team = [];
-      if (this.beingFetched) return [];
       team = this.team.filter((user) => (user.login.toLowerCase().includes(this.userFilter)));
       if (this.selectedColor) {
         team = team.filter((user) => (colorFromScore(user.score) === this.selectedColor));


### PR DESCRIPTION
#### Contexto
Se busca tener una tabla inicialmente en la cual se pueda ver todos los tags de cada una de las personas del equipo y se pueda filtrar por nombre y por tags.


#### Qué se está haciendo
- Se fijó el ancho de las columnas para que estas no cambiaran al aplicar los filtros
- Se fijó el alto de los comentarios en relación al alto de los tags (si es que los hay) y que el resto se scrolle ( si es que es muy largo).
- Se le agregó un alto mínimo a la tabla (para que quepan los dropdowns cuando no queda ningun usuaario tras aplicar un filtro)
- Se cambió el select de color a formato vertical (antes era horizontal)  y se le agregó la opción de seleccionar todas. 
- Se cambió el loading icon al componente teamTagsTableContainer, porque sino en  teamTagsTable fallaban los refs para calcular el alto de la fila.


#### Qué hay que revisar
- El componente TeamTagsTable, en el que se calcula el alto de la fila (para los comentarios)
- Los css de profile y clickable-dropdown

#### Más Información
Antes: 

https://user-images.githubusercontent.com/30674444/107387540-aee7c280-6ad3-11eb-80b8-9fba05180fe0.mov


Ahora: 

https://user-images.githubusercontent.com/30674444/107644196-e41c1e00-6c55-11eb-9df9-74196b1f38db.mov


Link del pitch: 
https://www.notion.so/Tags-3-99a5043d5aef4e69aa9a51ce7a820795

