### PR TITLE
fix(team-tags-table/colorFromScore): Show red for -1 scores in table

### DIFF
--- a/app/javascript/components/profile/team-tags-table.vue
+++ b/app/javascript/components/profile/team-tags-table.vue
@@ -149,7 +149,9 @@ export default {
     },
   },
   methods: {
-    colorFromScore,
+    colorFromScore(score) {
+      return colorFromScore(score, 'red');
+    },
     onColorClicked(event) {
       this.selectedColors[event.color] = !this.selectedColors[event.color];
       this.selectedColors = Object.assign({}, this.selectedColors);
@@ -179,7 +181,7 @@ export default {
     filteredTeam() {
       let team = [];
       team = this.team.filter((user) => (user.login.toLowerCase().includes(this.userFilter)));
-      team = team.filter((user) => (this.selectedColors[colorFromScore(user.score)]));
+      team = team.filter((user) => (this.selectedColors[this.colorFromScore(user.score)]));
       if (this.selectedTag) {
         team = team.filter((user) => (user.tags.map((tag) => (tag.name)).includes(this.selectedTag)));
       }

--- a/app/javascript/helpers/color-from-score.js
+++ b/app/javascript/helpers/color-from-score.js
@@ -1,6 +1,6 @@
-export default function colorFromScore(score) {
+export default function colorFromScore(score, noColor = '') {
   /* eslint-disable no-magic-numbers*/
-  if (score === -1.0) return '';
+  if (score === -1.0) return noColor;
 
   if (score <= 0.25) return 'red';
   if (score <= 0.5) return 'light-red';


### PR DESCRIPTION
#### Contexto
Si en un equipo habían personas con score -1,  ocurría un error en el mounted, la tabla no mostraba a los miembros del equipo y el select de tags no tomaba el ancho esperado. 

#### Qué se está haciendo
Se cambió a que en la tabla de tags las personas con score -1 (esto significa que  su promedio de  PRs es 0) tengan color 'red' en vez de un string vacío, para que no fallen los filtros ni  la clases de css para los círculos de colores de la tabla.  Así no ocurre un error en las filas de los usuarios con score negativo, lo que evita el error del mounted ( que ocurría al no encontrar refs de esos usuarios).  

#### En particular qué hay que revisar
- El helper colorFromScore, al que se le agregó el argumento noColor. Se dejó como valor default un string vacío (que era lo que retornaba antes) para no afectar los llamados a la función en otros lados.
- El componente TeamTagsTable, al que se le modificó el método colorFromScore, que llama al helper colorFromScore con noColor 'red'. 

#### Antes

https://user-images.githubusercontent.com/30674444/108285188-5bc1df80-7165-11eb-99e4-01c0c99639d3.mov

#### Ahora


https://user-images.githubusercontent.com/30674444/108285209-67ada180-7165-11eb-8a52-016ba1e39e16.mov





