### PR TITLE
Second criteria to sort recomendations

### DIFF
--- a/app/javascript/components/profile/relations.vue
+++ b/app/javascript/components/profile/relations.vue
@@ -52,6 +52,8 @@
 <script>
 import colorFromScore from '../../helpers/color-from-score';
 
+const SCORE_PRECISION = 2;
+
 export default {
   data() {
     return {
@@ -101,21 +103,14 @@ export default {
   methods: {
     colorFromScore,
     getTooltipMessage(user) {
-      if (!this.belongedTeam) {
-        const tagsText = user.tags.map(t => t.name).join('\n');
-        const text = `${user.login}\n tags: \n${user.tags.length ? tagsText : 'Aún no tiene tags'}`;
-
-        return text;
+      const score = user.score.toPrecision(SCORE_PRECISION);
+      let lastReviewFormat = '-';
+      if (user.last_review) {
+        const lastReviewDate = new Date(user.last_review);
+        lastReviewFormat = lastReviewDate.toLocaleDateString('es-CL', { dateStyle: 'short' });
       }
 
-      const userInfo = user.login.concat(' \n',
-        this.$t('message.organization.members.inactiveDays'),
-        this.inactiveDays[user.id],
-        ' \n',
-        this.$t('message.organization.members.score'),
-        this.colorScores[user.id]);
-
-      return userInfo;
+      return `${user.login}\n Puntaje: ${score}\n Última revisión: ${lastReviewFormat}`;
     },
   },
 };


### PR DESCRIPTION
## Objetivo
Ordenar las recomendaciones con un segundo criterio: última fecha de corrección de PR. Además, incluir el valor del puntajes y la última revisión de un usuario al hacer hover.

## Contexto
- Froggo ayuda a seleccionar a quién enviarle un PR.
- Actualmente estamos enfocados en perfeccionar esto.

## Descripción
- Se agrega para cada usuario la última fecha a la cuál le revisó un PR al usuario actual.
- Se agrega un segundo criterio al `sorted_by` para ordenar por la última fecha de revisión si esque el `:score` es el mismo.
- Se elimina los tags del hover porque existe un tabla para esto
- Se elimina código que no se utilizaba y que llamaba a métodos o properties que no existen.

## Extra
Así se veía antes:
![image](https://user-images.githubusercontent.com/26175977/110640662-d774e200-818f-11eb-846a-5ba3119d5936.png)
Así está ahora:
![image](https://user-images.githubusercontent.com/26175977/110640713-e6f42b00-818f-11eb-8fb5-de0ff34186b8.png)

Nótese que en la segunda foto cambió el orden y eso es porque se está ordenando también por la última revisión.