### PR TITLE
Setting view

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -29,6 +29,9 @@ class OrganizationsController < ApplicationController
   def missing; end
 
   def settings
+    if github_session.session_type == 'member'
+      redirect_to admin_authenticate_path(gh_org: @github_organization[:login])
+    end
     @is_admin_github_session = github_session.session[:client_type] == "admin"
     @teams = froggo_teams
   end


### PR DESCRIPTION
## Objetivo
Redirigir al usuario para que autorice la app en caso de que sea admin en Github y tenga permiso de :member en las cookies.

## Contexto
- Froggo se utiliza para recomendar a quién enviar tu próximo PR.

## Descripción
- En Froggo se utiliza OAuth de Github para generar un `access_token`.
- Todos ingresamos con un `access_token` con un scope de `:member`, es decir, que podemos hacer pocas cosas.
- Cuando eres :admin en Github de un repositorio y quieres configurarlo en Froggo, se te pidirá volver a generar este `access_token` para crearlo con permiso de `:admin`.