### PR TITLE
Find or create user when added to GitHub

### DIFF
--- a/app/assets/stylesheets/app/card.scss
+++ b/app/assets/stylesheets/app/card.scss
@@ -103,7 +103,7 @@ $roboto: 'Roboto', sans-serif;
       margin-top: 18px;
     }
 
-    &__dashboard-button {
+    &__button {
       margin: 0 auto;
       margin-top: 40px;
     }

--- a/app/commands/github/process_membership_event.rb
+++ b/app/commands/github/process_membership_event.rb
@@ -1,38 +1,30 @@
 class Github::ProcessMembershipEvent < PowerTypes::Command.new(:event_payload)
   def perform
-    read_payload
-    return unless event_team_is_default_team?
+    return if user.blank?
+    return organization_membership unless event_team_is_default_team?
 
-    @organization_membership.update!(is_member_of_default_team: member_of_default_team?)
+    organization_membership.update!(is_member_of_default_team: member_of_default_team?)
   end
 
   private
 
-  def read_payload
-    @event_action = data.action
-    @organization = Organization.find_by(gh_id: data.organization.id)
-    @user = GithubUser.find_by(gh_id: data.member.id)
-    @github_team_id = data.team.id
-    @organization_membership = OrganizationMembership.find_by(
-      github_user_id: @user.id,
-      organization_id: @organization.id
+  def organization_membership
+    @organization_membership ||= OrganizationMembership.find_or_create_by!(
+      github_user_id: user.id,
+      organization_id: organization.id
     )
   end
 
   def event_action_is_added?
-    @event_action === "added"
+    event_action === "added"
   end
 
   def event_action_is_removed?
-    @event_action === "removed"
+    event_action === "removed"
   end
 
   def event_team_is_default_team?
-    @github_team_id === @organization.default_team_id
-  end
-
-  def data
-    @data ||= @event_payload.is_a?(Hash) ? RecursiveOpenStruct.new(@event_payload) : @event_payload
+    github_team_id === organization.default_team_id
   end
 
   def member_of_default_team?
@@ -41,5 +33,25 @@ class Github::ProcessMembershipEvent < PowerTypes::Command.new(:event_payload)
     return false if event_action_is_removed?
 
     nil
+  end
+
+  def data
+    @data ||= @event_payload.is_a?(Hash) ? RecursiveOpenStruct.new(@event_payload) : @event_payload
+  end
+
+  def event_action
+    @event_action ||= data.action
+  end
+
+  def organization
+    @organization ||= Organization.find_by(gh_id: data.organization.id)
+  end
+
+  def user
+    @user ||= GithubUser.find_by(gh_id: data.member.id)
+  end
+
+  def github_team_id
+    @github_team_id ||= data.team.id
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -29,9 +29,6 @@ class OrganizationsController < ApplicationController
   def missing; end
 
   def settings
-    if github_session.session_type == 'member'
-      redirect_to admin_authenticate_path(gh_org: @github_organization[:login])
-    end
     @is_admin_github_session = github_session.session[:client_type] == "admin"
     @teams = froggo_teams
   end

--- a/app/views/organizations/_admin_permission.html.erb
+++ b/app/views/organizations/_admin_permission.html.erb
@@ -1,0 +1,19 @@
+<div class="card-extended">
+  <div class="card-extended__header">
+    <div class="card-extended__back" onclick="window.location.href='<%= organization_path(name: @github_organization[:login]) %>'">
+      <%= image_tag("back-arrow.svg", class: "card-extended__back-arrow") %>
+      <div class="card-extended__back-message">
+        <%= t('messages.settings.button_back') %>
+      </div>
+    </div>
+  </div>
+  <div class="card-extended__body">
+    <h2 class="card__title"><%= t('messages.settings.login_with_admin_session_ask') %></h2>
+    <p class="card__info"><%= t('messages.settings.login_with_admin_session_message_ask') %></p>
+    <div class="card-extended__button">
+      <%= link_to t('messages.settings.create_dashboard'),
+          admin_authenticate_path(gh_org: @github_organization[:login]),
+          class: "button button--big"%>
+    </div>
+  </div>
+</div>

--- a/app/views/organizations/_init.html.erb
+++ b/app/views/organizations/_init.html.erb
@@ -1,0 +1,21 @@
+<div class="card-extended">
+  <div class="card-extended__header">
+    <div class="card-extended__back" onclick="window.location.href='<%= organization_path(name: @github_organization[:login]) %>'">
+      <%= image_tag("back-arrow.svg", class: "card-extended__back-arrow") %>
+      <div class="card-extended__back-message">
+        <%= t('messages.settings.button_back') %>
+      </div>
+    </div>
+  </div>
+  <div class="card-extended__body">
+    <h2 class="card__title"><%= t('messages.settings.login_with_admin_session') %></h2>
+    <p class="card__info"><%= t('messages.settings.login_with_admin_session_message') %></p>
+    <div class="card-extended__button">
+      <%= button_to 'Crear Organización',
+          organizations_path,
+          method: :post,
+          params: { name: @github_organization[:login] },
+          class: "button button--big" %>
+    </div>
+  </div>
+</div>

--- a/app/views/organizations/settings.html.erb
+++ b/app/views/organizations/settings.html.erb
@@ -1,3 +1,9 @@
 <div class="settings">
-  <%= render "settings_content" %>
+  <% if !@is_admin_github_session %>
+    <%= render "admin_permission" %>
+  <% elsif @organization.present? %>
+    <%= render "settings_content" %>
+  <% else %>
+    <%= render "init" %>
+  <% end %>
 </div>

--- a/spec/commands/github/process_membership_event_spec.rb
+++ b/spec/commands/github/process_membership_event_spec.rb
@@ -5,48 +5,80 @@ describe Github::ProcessMembershipEvent do
     described_class.for(event_payload: event_payload)
   end
 
-  let!(:user) { create(:github_user, gh_id: 1) }
-  let!(:organization) { create(:organization, gh_id: 234, default_team_id: 123) }
+  let(:organization_gh_id) { 234 }
+  let(:team_id) { 123 }
+  let!(:organization) { create(:organization, gh_id: organization_gh_id, default_team_id: team_id) }
+  let(:member_payload) do
+    {
+      login: "Codertocat",
+      id: user_gh_id,
+      avatar_url: "",
+      html_url: ""
+    }
+  end
   let(:event_payload) do
-    double(
+    RecursiveOpenStruct.new(
       action: action,
-      member: double(id: 1),
-      team: double(id: 123),
-      organization: double(id: 234)
+      member: member_payload,
+      team: { id: team_id },
+      organization: { id: organization_gh_id }
     )
   end
 
-  context 'when user is added to default team in Github' do
-    let!(:organization_membership) do
-      create(
-        :organization_membership,
-        github_user: user,
-        organization: organization,
-        is_member_of_default_team: false
-      )
-    end
+  context 'when user does not exist in Froggo' do
     let(:action) { 'added' }
+    let(:user_gh_id) { 345 }
 
-    it 'user is added to default team in local DB' do
-      expect { perform }.to change { organization_membership.reload.is_member_of_default_team }
-        .from(false).to(true)
+    it "doesn't add a new Organization Membership for him" do
+      expect { perform }.not_to(change { OrganizationMembership.count })
     end
   end
 
-  context 'when user is removed from default team in Github' do
-    let!(:organization_membership) do
-      create(
-        :organization_membership,
-        github_user: user,
-        organization: organization,
-        is_member_of_default_team: true
-      )
-    end
-    let(:action) { 'removed' }
+  context 'when user already exists in Froggo' do
+    let(:user_gh_id) { 1234 }
+    let!(:user) { create(:github_user, gh_id: user_gh_id) }
 
-    it 'user is removed from default team in local DB' do
-      expect { perform }.to change { organization_membership.reload.is_member_of_default_team }
-        .from(true).to(false)
+    context 'when user is added to new organization' do
+      let(:action) { 'added' }
+      let(:organization_gh_id) { 456 }
+
+      it 'creates new Organization Membership' do
+        expect { perform }.to change { OrganizationMembership.count }.by(1)
+      end
+    end
+
+    context 'when user is added to default team in Github' do
+      let!(:organization_membership) do
+        create(
+          :organization_membership,
+          github_user: user,
+          organization: organization,
+          is_member_of_default_team: false
+        )
+      end
+      let(:action) { 'added' }
+
+      it 'user is added to default team in local DB' do
+        expect { perform }.to change { organization_membership.reload.is_member_of_default_team }
+          .from(false).to(true)
+      end
+    end
+
+    context 'when user is removed from default team in Github' do
+      let!(:organization_membership) do
+        create(
+          :organization_membership,
+          github_user: user,
+          organization: organization,
+          is_member_of_default_team: true
+        )
+      end
+      let(:action) { 'removed' }
+
+      it 'user is removed from default team in local DB' do
+        expect { perform }.to change { organization_membership.reload.is_member_of_default_team }
+          .from(true).to(false)
+      end
     end
   end
 end

--- a/spec/controllers/github_auth_controller_spec.rb
+++ b/spec/controllers/github_auth_controller_spec.rb
@@ -5,13 +5,16 @@ RSpec.describe GithubAuthController, type: :controller do
     let(:github_return_code) { 'github_code' }
     let(:token_result) { { access_token: 'token' } }
     let(:path) { nil }
+    let(:gh_organizations) { [] }
+    let(:gh_user_id) { 123 }
+    let(:gh_user) { create(:github_user, gh_id: gh_user_id) }
     let!(:github_session) do
-      double(
-        name: 'name',
+      instance_double(
+        'GithubSession',
         set_session: [],
         froggo_path: path,
-        user: 1,
-        token: 'token'
+        token: 'token',
+        user: gh_user
       )
     end
 
@@ -19,8 +22,36 @@ RSpec.describe GithubAuthController, type: :controller do
       allow(Octokit).to receive(:exchange_code_for_token)
         .with(github_return_code, ENV['GH_AUTH_ID'], ENV['GH_AUTH_SECRET'])
         .and_return(token_result)
-      allow(subject).to receive(:github_session)
-        .and_return(github_session)
+      allow(controller).to receive(:github_session).and_return(github_session)
+      allow(github_session).to receive(:organizations).and_return(gh_organizations)
+    end
+
+    context 'when user has more organizations in Github that in Froggo' do
+      let(:first_organization) { create(:organization) }
+      let(:second_organization) { create(:organization) }
+      let(:expected_organization_memberships) { 2 }
+      let(:gh_organizations) do
+        [{ id: first_organization.gh_id }, { id: second_organization.gh_id }, { id: 234 }]
+      end
+
+      before do
+        get :callback, params: { client_type: :member, code: github_return_code }
+      end
+
+      it 'creates organization membership in first_organization and second_organization' do
+        expect(
+          OrganizationMembership.find_by(organization: first_organization, github_user: gh_user)
+        ).not_to be_nil
+        expect(
+          OrganizationMembership.find_by(organization: first_organization, github_user: gh_user)
+        ).not_to be_nil
+      end
+
+      it 'does not create organization membership in third organization' do
+        expect(
+          OrganizationMembership.where(github_user: gh_user).count
+        ).to be(expected_organization_memberships)
+      end
     end
 
     context 'from home without last path in github session' do

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -131,12 +131,6 @@ RSpec.describe OrganizationsController, type: :controller do
       before { github_session }
 
       it { expect(response).to redirect_to('/organizations/platanus') }
-
-      context 'when user is admin in Github' do
-        let(:role) { 'admin' }
-
-        it { expect(response).to redirect_to(admin_authenticate_path(gh_org: organization_name)) }
-      end
     end
   end
 end


### PR DESCRIPTION
## Objetivo
Incorporar nuevamente la creación de una Organización en Froggo ya que la borré por accidente en un PR anterior.
Crear la instancia de la relación entre organización y usuario (`OrganizationMembership`) en el webhook y al momento de crear un usuario.

## Contexto
- Froggo se utiliza para recomendar a quién enviar tu próximo PR.
- Estamos volviendo a las bases y mejorando el onboarding y usabilidad.

## Descripción
- Al agregar un usuario en Github el webhook intentará crear una relación con la orgnización si no está creada.
- El método `callback` de `GithubAuthController` es al que llama Github después de autentificar a un usuario. En este método ahora se intentará crear la relación con todas las organizaciones en Froggo que pertenezca el usuario en Github.
- Se corrigió un error que cometí al borrar algunas cosas en un PR anterior. 