### PR TITLE
Centralize api calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,7 +242,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
@@ -579,4 +579,4 @@ DEPENDENCIES
   webpacker (~> 4.0)
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/app/javascript/api/froggo_teams.js
+++ b/app/javascript/api/froggo_teams.js
@@ -1,0 +1,24 @@
+import api from './index';
+
+export default {
+  createFroggoTeam(organizationId, body) {
+    return api({
+      method: 'post',
+      url: `/api/organizations/${organizationId}/froggo_teams`,
+      data: body,
+    });
+  },
+  updateFroggoTeam(teamId, body) {
+    return api({
+      method: 'patch',
+      url: `/api/froggo_teams/${teamId}`,
+      data: body,
+    });
+  },
+  deleteFroggoTeam(teamId) {
+    return api({
+      method: 'delete',
+      url: `/api/froggo_teams/${teamId}`,
+    });
+  },
+};

--- a/app/javascript/api/index.js
+++ b/app/javascript/api/index.js
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import { camelizeKeys, decamelizeKeys } from 'humps';
+import map from 'lodash/map';
+import capitalize from 'lodash/capitalize';
+
+const tokenEl = document && document.querySelector('meta[name="csrf-token"]');
+const CSRFToken = tokenEl && tokenEl.getAttribute('content');
+
+const api = axios.create({
+  headers: {
+    'X-CSRF-Token': CSRFToken,
+  },
+});
+
+api.interceptors.response.use(
+  response => {
+    if (response.data && response.headers['content-type'].match('application/json')) {
+      response.data = camelizeKeys(response.data);
+    }
+
+    return response;
+  },
+  error => {
+    if (error.response) {
+      const { data } = error.response;
+      switch (data.message) {
+      case 'invalid_attributes':
+        error.details = map(data.errors, (errorMessage, attribute) => capitalize(`${attribute} ${errorMessage}`));
+        break;
+      case 'server_error':
+        error.details = [`Error interno del servidor: ${data.detail}`];
+        break;
+      default:
+        break;
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
+
+api.interceptors.request.use(config => {
+  const newConfig = { ...config };
+  if (newConfig.headers['Content-Type'] === 'multipart/form-data') {
+    return newConfig;
+  }
+  if (config.params) {
+    newConfig.params = decamelizeKeys(config.params);
+  }
+  if (config.data) {
+    newConfig.data = decamelizeKeys(config.data);
+  }
+
+  return newConfig;
+});
+
+export default api;

--- a/app/javascript/api/organizations.js
+++ b/app/javascript/api/organizations.js
@@ -1,0 +1,23 @@
+import api from './index';
+
+export default {
+  checkSync(organizationId) {
+    return api({
+      method: 'get',
+      url: `/api/organizations/${organizationId}/check_sync`,
+    });
+  },
+  sync(organizationId) {
+    return api({
+      method: 'post',
+      url: `/api/organizations/${organizationId}/sync`,
+    });
+  },
+  update(organizationId, body) {
+    return api({
+      method: 'put',
+      url: `/api/organizations/${organizationId}/update`,
+      data: body,
+    });
+  },
+};

--- a/app/javascript/api/pull_request_reviewers.js
+++ b/app/javascript/api/pull_request_reviewers.js
@@ -1,11 +1,11 @@
-import axios from 'axios';
-import { decamelizeKeys } from 'humps';
+import api from './index';
 
 export default {
   addReviewer(data) {
-    return axios.post(
-      '/api/pull_request_reviewer/add',
-      decamelizeKeys(data),
-    );
+    return api({
+      method: 'post',
+      url: '/api/pull_request_reviewer/add',
+      data,
+    });
   },
 };

--- a/app/javascript/api/pull_requests.js
+++ b/app/javascript/api/pull_requests.js
@@ -1,0 +1,16 @@
+import api from './index';
+
+export default {
+  addLike(prId) {
+    return api({
+      method: 'post',
+      url: `/api/pull_requests/${prId}/likes`,
+    });
+  },
+  deleteLike(prId, userLikeId) {
+    return api({
+      method: 'delete',
+      url: `/api/pull_requests/${prId}/likes/${userLikeId}`,
+    });
+  },
+};

--- a/app/javascript/api/repositories.js
+++ b/app/javascript/api/repositories.js
@@ -1,0 +1,11 @@
+import api from './index';
+
+export default {
+  updateRepository(repositoryId, body) {
+    return api({
+      method: 'put',
+      url: `/api/repositories/${repositoryId}`,
+      data: body,
+    });
+  },
+};

--- a/app/javascript/api/users.js
+++ b/app/javascript/api/users.js
@@ -1,0 +1,25 @@
+import api from './index';
+
+export default {
+  updateUser(userId, body) {
+    return api({
+      method: 'patch',
+      url: `/api/github_users/${userId}`,
+      data: body,
+    });
+  },
+  getUserRecommendations(teamId, userLogin, queryParams) {
+    return api({
+      method: 'get',
+      url: `/api/teams/${teamId}/users/${userLogin}/recommendations`,
+      params: queryParams,
+    });
+  },
+  pullRequestsInformation(userLogin, monthLimit) {
+    return api({
+      method: 'get',
+      url: `/api/users/${userLogin}/pull_requests_information`,
+      params: { monthLimit },
+    });
+  },
+};

--- a/app/javascript/components/dashboard-syncing-icon.vue
+++ b/app/javascript/components/dashboard-syncing-icon.vue
@@ -4,7 +4,7 @@
 
 <script>
 /* eslint-disable no-alert */
-import axios from 'axios';
+import organizationsApi from '../api/organizations';
 
 export default {
   props: ['id'],
@@ -16,7 +16,7 @@ export default {
   methods: {
     checkSync() {
       const TIMEOUT = 5000;
-      axios.get(`/api/organizations/${this.id}/check_sync`)
+      organizationsApi.checkSync(this.id)
         .then((res) => {
           if (res.data.state === 'completed') {
             if (this.loading === true) {

--- a/app/javascript/components/froggo-team-edit.vue
+++ b/app/javascript/components/froggo-team-edit.vue
@@ -53,7 +53,7 @@
         >
           <img
             class="froggo-teams-show__picture"
-            :src="user.avatar_url"
+            :src="user.avatarUrl"
           >
           <div class="froggo-teams-show__username">
             {{ user.login }}

--- a/app/javascript/components/froggo-team-show.vue
+++ b/app/javascript/components/froggo-team-show.vue
@@ -21,7 +21,7 @@
         >
           <img
             class="froggo-teams-show__picture"
-            :src="user.avatar_url"
+            :src="user.avatarUrl"
           >
           <div class="froggo-teams-show__username">
             {{ user.login }}

--- a/app/javascript/components/open-pr.vue
+++ b/app/javascript/components/open-pr.vue
@@ -26,7 +26,7 @@
         >
           <img
             class="select-reviewer__picture"
-            :src="rev.avatar_url"
+            :src="rev.avatarUrl"
           >
           <span
             class="select-reviewer__username"
@@ -65,7 +65,7 @@
           <div class="select-reviewer__container">
             <img
               class="select-reviewer__picture"
-              :src="option.avatar_url"
+              :src="option.avatarUrl"
             >
             <span
               class="select-reviewer__username"
@@ -112,7 +112,7 @@ export default {
       return this.pr.id;
     },
     prHref() {
-      return this.pr.html_url;
+      return this.pr.htmlUrl;
     },
   },
   props: {

--- a/app/javascript/components/pr-feed.vue
+++ b/app/javascript/components/pr-feed.vue
@@ -72,9 +72,8 @@
 
 <script>
 
-import axios from 'axios';
 import moment from 'moment';
-import { decamelizeKeys } from 'humps';
+import pullRequestsApi from '../api/pull_requests';
 
 export default {
   props: {
@@ -105,26 +104,24 @@ export default {
   methods: {
 
     toggleLike(pr) {
-      axios.post(
-        `/api/pull_requests/${pr.id}/likes`, decamelizeKeys,
-      ).then(response => {
-        pr.likes += 1;
-        pr.currentUserLike = response.data;
-      }).catch(() => {
-        // eslint-disable-next-line no-alert
-        alert('No se pudo crear el like (solo se puede dar un like por PR)');
-      });
+      pullRequestsApi.addLike(pr.id)
+        .then(response => {
+          pr.likes += 1;
+          pr.currentUserLike = response.data;
+        }).catch(() => {
+          // eslint-disable-next-line no-alert
+          alert('No se pudo crear el like (solo se puede dar un like por PR)');
+        });
     },
     deleteLike(pr) {
-      axios.delete(
-        `/api/pull_requests/${pr.id}/likes/${pr.currentUserLike.id}`,
-      ).then(() => {
-        pr.likes -= 1;
-        pr.currentUserLike = undefined;
-      }).catch(() => {
-        // eslint-disable-next-line no-alert
-        alert('No se pudo borrar el like (no haz dado like primero)');
-      });
+      pullRequestsApi.deleteLike(pr.id, pr.currentUserLike.id)
+        .then(() => {
+          pr.likes -= 1;
+          pr.currentUserLike = undefined;
+        }).catch(() => {
+          // eslint-disable-next-line no-alert
+          alert('No se pudo borrar el like (no haz dado like primero)');
+        });
     },
     prDate(pr) {
       return moment(pr.createdAt).format('DD-MM-YYYY');

--- a/app/javascript/components/pr-feed.vue
+++ b/app/javascript/components/pr-feed.vue
@@ -74,8 +74,10 @@
 
 import moment from 'moment';
 import pullRequestsApi from '../api/pull_requests';
+import showMessageMixin from '../mixins/showMessageMixin';
 
 export default {
+  mixins: [showMessageMixin],
   props: {
     pullRequests: {
       type: Array,
@@ -102,15 +104,13 @@ export default {
   },
 
   methods: {
-
     toggleLike(pr) {
       pullRequestsApi.addLike(pr.id)
         .then(response => {
           pr.likes += 1;
           pr.currentUserLike = response.data;
         }).catch(() => {
-          // eslint-disable-next-line no-alert
-          alert('No se pudo crear el like (solo se puede dar un like por PR)');
+          this.showMessage(this.$i18n.t('message.error.createLike'));
         });
     },
     deleteLike(pr) {
@@ -119,8 +119,7 @@ export default {
           pr.likes -= 1;
           pr.currentUserLike = undefined;
         }).catch(() => {
-          // eslint-disable-next-line no-alert
-          alert('No se pudo borrar el like (no haz dado like primero)');
+          this.showMessage(this.$i18n.t('message.error.deleteLike'));
         });
     },
     prDate(pr) {

--- a/app/javascript/components/pr-show.vue
+++ b/app/javascript/components/pr-show.vue
@@ -111,9 +111,8 @@
 </template>
 
 <script>
-import axios from 'axios';
 import moment from 'moment';
-import { decamelizeKeys } from 'humps';
+import pullRequestsApi from '../api/pull_requests';
 
 export default {
   props: {
@@ -142,8 +141,7 @@ export default {
 
   methods: {
     toggleLike(pr) {
-      axios
-        .post(`/api/pull_requests/${pr.id}/likes`, decamelizeKeys)
+      pullRequestsApi.addLike(pr.id)
         .then((response) => {
           pr.likes += 1;
           pr.currentUserLike = response.data;
@@ -154,8 +152,7 @@ export default {
         });
     },
     deleteLike(pr) {
-      axios
-        .delete(`/api/pull_requests/${pr.id}/likes/${pr.currentUserLike.id}`)
+      pullRequestsApi.deleteLike(pr.id, pr.currentUserLike.id)
         .then(() => {
           pr.likes -= 1;
           pr.currentUserLike = undefined;

--- a/app/javascript/components/pr-show.vue
+++ b/app/javascript/components/pr-show.vue
@@ -113,8 +113,10 @@
 <script>
 import moment from 'moment';
 import pullRequestsApi from '../api/pull_requests';
+import showMessageMixin from '../mixins/showMessageMixin';
 
 export default {
+  mixins: [showMessageMixin],
   props: {
     pullRequest: {
       type: Object,
@@ -147,8 +149,7 @@ export default {
           pr.currentUserLike = response.data;
         })
         .catch(() => {
-          // eslint-disable-next-line no-alert
-          alert('No se pudo crear el like (solo se puede dar un like por PR)');
+          this.showMessage(this.$i18n.t('message.error.createLike'));
         });
     },
     deleteLike(pr) {
@@ -158,8 +159,7 @@ export default {
           pr.currentUserLike = undefined;
         })
         .catch(() => {
-          // eslint-disable-next-line no-alert
-          alert('No se pudo borrar el like (no haz dado like primero)');
+          this.showMessage(this.$i18n.t('message.error.deleteLike'));
         });
     },
     prDate(pr) {

--- a/app/javascript/components/profile-description.vue
+++ b/app/javascript/components/profile-description.vue
@@ -93,7 +93,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import usersApi from '../api/users';
 
 export default {
 
@@ -116,7 +116,7 @@ export default {
       this.readMoreActivated = false;
     },
     submit() {
-      axios.patch(`/api/github_users/${String(this.githubUser.id)}`, this.form)
+      usersApi.updateUser(this.githubUser.id, this.form)
         // eslint-disable-next-line max-statements
         .then((res) => {
           this.user = res.data.user;

--- a/app/javascript/components/profile/recommendations-users.vue
+++ b/app/javascript/components/profile/recommendations-users.vue
@@ -20,7 +20,7 @@
       >
         <img
           class="profile-recommendations-users__picture"
-          :src="user.avatar_url"
+          :src="user.avatarUrl"
         >
         <div class="profile-recommendations-users__username">
           {{ user.login }}

--- a/app/javascript/components/profile/relations.vue
+++ b/app/javascript/components/profile/relations.vue
@@ -37,7 +37,7 @@
                 />
                 <img
                   class="profile-relations__picture"
-                  :src="item.avatar_url"
+                  :src="item.avatarUrl"
                   v-tooltip.right="getTooltipMessage(item)"
                 >
               </div>

--- a/app/javascript/components/profile/team-tags-table.vue
+++ b/app/javascript/components/profile/team-tags-table.vue
@@ -67,7 +67,7 @@
             >
               <img
                 class="profile-team-tags-table__picture"
-                :src="user.avatar_url"
+                :src="user.avatarUrl"
               >
               <div class="profile-team-tags-table__username">
                 {{ user.login }}

--- a/app/javascript/components/repository.vue
+++ b/app/javascript/components/repository.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import axios from 'axios';
+import repositoriesApi from '../api/repositories';
 
 export default {
   data() {
@@ -33,8 +33,7 @@ export default {
     },
     setTrackedStatus(status) {
       this.repository.tracked = status;
-
-      axios.put(`/api/repositories/${this.repository.id}`, { tracked: status })
+      repositoriesApi.updateRepository(this.repository.id, { tracked: status })
         .then((response) => {
           console.log(response);
         })

--- a/app/javascript/components/sync-organization-button.vue
+++ b/app/javascript/components/sync-organization-button.vue
@@ -7,7 +7,7 @@
 
 <script>
 /* eslint-disable no-alert */
-import axios from 'axios';
+import organizationsApi from '../api/organizations';
 
 export default {
   props: ['id'],
@@ -22,7 +22,7 @@ export default {
         return;
       }
       this.loading = true;
-      axios.post(`/api/organizations/${this.id}/sync`)
+      organizationsApi.sync(this.id)
         .then(() => {
           this.checkSync();
         })
@@ -32,7 +32,7 @@ export default {
     },
     checkSync() {
       const TIMEOUT = 1000;
-      axios.get(`/api/organizations/${this.id}/check_sync`)
+      organizationsApi.checkSync(this.id)
         .then((res) => {
           if (res.data.state === 'completed') {
             this.loading = false;

--- a/app/javascript/components/user-tags.vue
+++ b/app/javascript/components/user-tags.vue
@@ -76,9 +76,9 @@
   </div>
 </template>
 <script>
-import axios from 'axios';
 import ClickableDropdown from './clickable-dropdown';
 import TagsShow from './tags-show';
+import usersApi from '../api/users';
 
 export default {
   components: {
@@ -121,9 +121,8 @@ export default {
       return element.id;
     },
     editTags(ids) {
-      axios.patch(`/api/github_users/${this.githubSession.user.id}`, {
-        // eslint-disable-next-line camelcase
-        tag_ids: [... ids],
+      usersApi.updateUser(this.githubSession.user.id, {
+        tagIds: [... ids],
       })
         .then((res) => {
           this.myTags = res.data.tags;

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -85,6 +85,8 @@ export default {
     error: {
       unauthorized: 'No tiene autorización para realizar esta acción',
       existentName: 'Ese nombre ya existe para un equipo de la organización',
+      createLike: 'No se pudo crear el like (sólo se puede dar un like por PR)',
+      deleteLike: 'No se pudo borrar el like (no has dado like primero)',
     },
     metrics: {
       noPullRequestInformation: 'No hay información de pull requests para obtener métricas',

--- a/app/javascript/store/modules/admin/actions.js
+++ b/app/javascript/store/modules/admin/actions.js
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import organizationsApi from '../../../api/organizations';
 
 import {
   UPDATE_DEFAULT_TEAM,
@@ -6,10 +6,9 @@ import {
 
 export default {
   [UPDATE_DEFAULT_TEAM](_, { teamId, organization, froggoTeam }) {
-    axios
-      .put(`/api/organizations/${organization.id}/update`, {
-        'default_team_id': teamId,
-        'froggo_team': froggoTeam,
-      });
+    organizationsApi.update(organization.id, {
+      'default_team_id': teamId,
+      'froggo_team': froggoTeam,
+    });
   },
 };

--- a/app/javascript/store/modules/froggo_team/actions.js
+++ b/app/javascript/store/modules/froggo_team/actions.js
@@ -1,5 +1,6 @@
-import axios from 'axios';
-import { decamelizeKeys } from 'humps';
+import froggoTeamsApi from '../../../api/froggo_teams';
+import usersApi from '../../../api/users';
+
 import {
   CREATE_NEW_FROGGO_TEAM,
   UPDATE_FROGGO_TEAM,
@@ -15,21 +16,26 @@ import {
 
 export default {
   [CREATE_NEW_FROGGO_TEAM](_, { name, organizationId, userIds }) {
-    return axios.post(
-      `/api/organizations/${organizationId}/froggo_teams`, decamelizeKeys({ name, newMembersIds: userIds }));
+    froggoTeamsApi.createFroggoTeam(organizationId, {
+      name,
+      newMembersIds: userIds,
+    });
   },
 
   [UPDATE_FROGGO_TEAM](_, { id, name, newMembersIds, oldMembersIds, changedMembersIds, changedPercentages }) {
-    return axios.patch(
-      `/api/froggo_teams/${id}`,
-      decamelizeKeys({ name, newMembersIds, oldMembersIds, changedMembersIds, changedPercentages }),
-    );
+    froggoTeamsApi.updateFroggoTeam(id, {
+      name,
+      newMembersIds,
+      oldMembersIds,
+      changedMembersIds,
+      changedPercentages,
+    });
   },
 
   [DELETE_FROGGO_TEAM](_, { id }) {
     const response = confirm('Estás seguro de querer borrar el equipo ?');
     if (response) {
-      return axios.delete(`/api/froggo_teams/${id}`);
+      froggoTeamsApi.deleteFroggoTeam(id);
     }
 
     return false;
@@ -40,12 +46,7 @@ export default {
     let pullRequestsInformation = {};
     const promises = [];
     githubUsers.forEach((user) => {
-      promises.push(axios
-        .get(`/api/users/${user.login}/pull_requests_information`, {
-          params: decamelizeKeys({
-            monthLimit,
-          }),
-        }));
+      promises.push(usersApi.pullRequestsInformation(user.login, monthLimit));
     });
     Promise.all(promises)
       .then(responses => {

--- a/app/javascript/store/modules/profile/actions.js
+++ b/app/javascript/store/modules/profile/actions.js
@@ -1,5 +1,4 @@
-import axios from 'axios';
-import { decamelizeKeys } from 'humps';
+import usersApi from '../../../api/users';
 
 import {
   COMPUTE_RECOMMENDATIONS,
@@ -29,13 +28,8 @@ export default {
 
   [COMPUTE_RECOMMENDATIONS]({ commit }, { teamId, githubUserLogin, monthLimit, froggoTeam }) {
     commit(START_FETCHING_RECOMMENDATIONS);
-    axios
-      .get(`/api/teams/${teamId}/users/${githubUserLogin}/recommendations`, {
-        params: decamelizeKeys({
-          monthLimit,
-          froggoTeam,
-        }),
-      })
+    const params = { monthLimit, froggoTeam };
+    usersApi.getUserRecommendations(teamId, githubUserLogin, params)
       .then(response => {
         commit(RECOMMENDATIONS_RECEIVED, response.data.response.recommendations);
       })
@@ -46,12 +40,7 @@ export default {
 
   [COMPUTE_PROFILE_PR_INFORMATION]({ commit }, { githubUserLogin, monthLimit }) {
     commit(START_FETCHING_PR_INFORMATION);
-    axios
-      .get(`/api/users/${githubUserLogin}/pull_requests_information`, {
-        params: decamelizeKeys({
-          monthLimit,
-        }),
-      })
+    usersApi.pullRequestsInformation(githubUserLogin, monthLimit)
       .then(response => {
         commit(PROFILE_PR_INFORMATION_RECEIVED, response.data.response.metrics);
       })

--- a/app/views/froggo_teams/edit.html.erb
+++ b/app/views/froggo_teams/edit.html.erb
@@ -3,9 +3,9 @@
     <div class="froggo-teams">
       <froggo-team-edit
         :user-id="<%= @github_user.id %>"
-        :froggo-team="<%= @froggo_team.to_json %>"
-        :froggo-team-members="<%= @froggo_team_members.to_json %>"
-        :organization-members="<%= @organization_members.to_json %>"
+        :froggo-team="<%= @froggo_team.to_json %> | camelizeKeys"
+        :froggo-team-members="<%= @froggo_team_members.to_json %> | camelizeKeys"
+        :organization-members="<%= @organization_members.to_json %> | camelizeKeys"
       />
     </div>
   </div>

--- a/app/views/froggo_teams/show.html.erb
+++ b/app/views/froggo_teams/show.html.erb
@@ -3,14 +3,14 @@
     <div class="froggo-teams">
       <froggo-team-show
         :froggo-team="<%= @froggo_team.to_json %>"
-        :froggo-team-members="<%= @froggo_team_members.to_json %>"
+        :froggo-team-members="<%= @froggo_team_members.to_json %> | camelizeKeys"
       />
     </div>
   </div>
 </div>
 <div class="container card froggo-teams">
   <froggo-team-metrics
-    :froggo-team-members="<%= @froggo_team_members.to_json %>"
+    :froggo-team-members="<%= @froggo_team_members.to_json %> | camelizeKeys"
     :months-options="<%= timespans_with_name.to_json %>"
   />
 </div>

--- a/app/views/github_users/_profile_card.html.erb
+++ b/app/views/github_users/_profile_card.html.erb
@@ -42,8 +42,8 @@
   <div class="profile-prs">
     <% @open_prs.each do |pr| %>
         <open-pr
-          :pr="<%= pr[:pull_request].to_json %>"
-          :reviewers="<%= pr[:reviewers].to_json %>"
+          :pr="<%= pr[:pull_request].to_json %> | camelizeKeys"
+          :reviewers="<%= pr[:reviewers].to_json %> | camelizeKeys"
         >
         </open-pr>
     <% end %>


### PR DESCRIPTION
### Contexto
Queremos todas las llamadas a la API desde uno o varios archivos.

### Qué se esta haciendo
Se crea el `index.js` con el método api que se usará en las llamadas (copiado directamente de [Mute](https://github.com/platanus/mute-meetings/blob/development/app/javascript/api/index.js))
Se crean los archivos para cada categoría de llamada a la api.
Se reemplazan las llamadas en los componentes y actions por los métodos de los archivos nuevos.
Se camelizan los props de users que se pasan en vistas rails para que sea consistente con los responses de la api de users.

#### En particular hay que revisar
Que no se me haya pasado algún prop que haya dejado de funcionar por no estar camelizado :grimacing: 