### PR TITLE
Enable tailwind

### DIFF
--- a/.postcssrc.yml
+++ b/.postcssrc.yml
@@ -1,3 +1,0 @@
-plugins:
-  postcss-smart-import: {}
-  postcss-cssnext: {}

--- a/app/assets/stylesheets/app/_base.scss
+++ b/app/assets/stylesheets/app/_base.scss
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500|Roboto+Condensed:300');
-
 $main-font: 'Roboto';
 $landing-font: 'Roboto', sans-serif;
 $roboto-condensed: 'Roboto Condensed';

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ import VueHorizontalList from 'vue-horizontal-list';
 import Toasted from 'vue-toasted';
 import { camelizeKeys } from 'humps';
 import vSelect from 'vue-select';
+import '../css/application.css';
 
 import Dropdown from '../components/pl-dropdown.vue';
 import TeamsDropdown from '../components/teams-dropdown.vue';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <%= render partial: 'partials/tag_manager_head' %>
     <title>Froggo - Platanus</title>
     <%= csrf_meta_tags %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,12 @@
 /* eslint-disable no-undef */
 module.exports = {
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        'main': ['Roboto', 'sans-serif'],
+        'landing': ['Roboto', 'sans-serif'],
+      },
+    },
   },
   variants: {},
   plugins: [],


### PR DESCRIPTION
## Objetivo
Dejar habilitado tailwind para desarrollo.

## Contexto
- Froggo se utiliza para recomendar a quién enviar tu próximo PR.

## Descripción
- Se eliminó el archivo `postcssrc.yml` ya que ahora se utiliza `postcss.config.js`.
- Se movió la carga de font para que se el head. Esto resuelve el problema de distintos fonts en desarrollo y en producción.
- Se incluye el css a vue para que tailwind funcione.
- Se agrega una configuración básica de tailwind.