### PR TITLE
Froggo ext endpoints

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -1,7 +1,11 @@
 class Api::V1::OrganizationsController < Api::V1::BaseController
   before_action :authenticate_github_user
-  before_action :ensure_organization_admin
+  before_action :ensure_organization_admin, except: [:index]
   after_action :update_organization_default_team_memberships, only: [:update]
+
+  def index
+    respond_with github_user.organizations
+  end
 
   def sync
     Github::OrganizationWebhookService.new(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
       resources :pull_requests do
         resources :likes, only: [:create, :destroy]
       end
+      resources :github_users, only: [] do
+        get '/open_prs' => :open_prs, on: :collection
+      end
       patch 'github_users/:id' => 'github_users#update'
       get 'users/:github_login/pull_requests_information' =>
         'github_users#pull_requests_information'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
         'github_users#organization_recommendation_statistics'
       get 'teams/:team_id/users/:github_login/recommendations' =>
         'github_users#team_review_recommendations'
-      resources :organizations do
+      resources :organizations, only: [:index] do
         resources :froggo_teams, only: [:index, :show, :create, :destroy, :update], shallow: true
       end
       resources :pull_requests do


### PR DESCRIPTION
### Contexto
Estoy trabajando en la extensión de Chrome para Froggo y hay un par de endpoints que me faltan de API

### Que se hace
Se agregan los siguientes endpoints
- Obtener las organizaciones del usuario logueado
- Obtener los prs abiertos del usuario logueado