### PR TITLE
Create Preference model

### DIFF
--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -1,0 +1,32 @@
+class Preference < ApplicationRecord
+  belongs_to :user
+  enum default_time: {
+    one_month: 0,
+    three_months: 1,
+    six_months: 2,
+    nine_months: 3,
+    twelve_months: 4
+  }
+  validates :default_organization_id, :default_team_id, :default_time, presence: true
+end
+
+# == Schema Information
+#
+# Table name: preferences
+#
+#  id                      :bigint(8)        not null, primary key
+#  default_organization_id :bigint(8)
+#  default_team_id         :bigint(8)
+#  default_time            :bigint(8)
+#  user_id                 :bigint(8)        not null
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# Indexes
+#
+#  index_preferences_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_one :preference, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20210602150223_create_preferences.rb
+++ b/db/migrate/20210602150223_create_preferences.rb
@@ -1,0 +1,12 @@
+class CreatePreferences < ActiveRecord::Migration[6.0]
+  def change
+    create_table :preferences do |t|
+      t.bigint :default_organization_id
+      t.bigint :default_team_id
+      t.bigint :default_time
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_29_155013) do
+ActiveRecord::Schema.define(version: 2021_06_02_150223) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,6 +143,16 @@ ActiveRecord::Schema.define(version: 2020_12_29_155013) do
     t.integer "default_team_id"
   end
 
+  create_table "preferences", force: :cascade do |t|
+    t.bigint "default_organization_id"
+    t.bigint "default_team_id"
+    t.bigint "default_time"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_preferences_on_user_id"
+  end
+
   create_table "pull_request_relations", force: :cascade do |t|
     t.bigint "pull_request_id"
     t.bigint "github_user_id"
@@ -258,6 +268,7 @@ ActiveRecord::Schema.define(version: 2020_12_29_155013) do
   add_foreign_key "organization_memberships", "github_users"
   add_foreign_key "organization_memberships", "organizations"
   add_foreign_key "organization_syncs", "organizations"
+  add_foreign_key "preferences", "users"
   add_foreign_key "pull_request_relations", "github_users"
   add_foreign_key "pull_request_relations", "pull_requests"
   add_foreign_key "pull_request_review_requests", "github_users"

--- a/spec/factories/preferences.rb
+++ b/spec/factories/preferences.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :preference do
+  end
+end

--- a/spec/factories/preferences.rb
+++ b/spec/factories/preferences.rb
@@ -1,4 +1,9 @@
 FactoryBot.define do
   factory :preference do
+    association :user
+
+    default_organization_id { 1 }
+    default_team_id { 1 }
+    default_time { 0 }
   end
 end

--- a/spec/models/preference_spec.rb
+++ b/spec/models/preference_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Preference, type: :model do
+  it 'has a valid factory' do
+    expect(build(:preference)).to be_valid
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of :default_organization_id }
+    it { is_expected.to validate_presence_of :default_team_id }
+    it { is_expected.to validate_presence_of :default_time }
+  end
+
+  describe 'relationships' do
+    it { is_expected.to belong_to(:user) }
+  end
+end


### PR DESCRIPTION
### Contexto

En Froggo, actualmente las preferencias del usuario se guardan en el storage del navegador. Si un usuario cambia de navegador o usa la nueva extensión, las preferencias desaparecen por no estar guardadas en el backend.

### Qué se está haciendo

-  Se crea el modelo `Preference`, que contiene las preferencias de un usuario para una organización (`default_organization_id`), equipo (`default_team_id`) y el tiempo (`default_time`) con un enum para determinar los tiempos disponibles.
- Se agregan los tests de validación y relación. 