### PR TITLE
Fix: Associate Preferences with GithubUser instead of User

### DIFF
--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -15,6 +15,8 @@ class GithubUser < ApplicationRecord
   has_many :taggings, as: :taggable, dependent: :destroy
   has_many :tags, through: :taggings
 
+  has_one :preference, dependent: :destroy
+
   validates :gh_id, presence: true
   validates :login, presence: true
   validates :description, length: { maximum: 255 }

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -1,5 +1,5 @@
 class Preference < ApplicationRecord
-  belongs_to :user
+  belongs_to :github_user
   enum default_time: {
     one_month: 0,
     three_months: 1,
@@ -18,15 +18,15 @@ end
 #  default_organization_id :bigint(8)
 #  default_team_id         :bigint(8)
 #  default_time            :bigint(8)
-#  user_id                 :bigint(8)        not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  github_user_id          :bigint(8)
 #
 # Indexes
 #
-#  index_preferences_on_user_id  (user_id)
+#  index_preferences_on_github_user_id  (github_user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (github_user_id => github_users.id)
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 class User < ApplicationRecord
-  has_one :preference, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20210614120524_remove_user_id_from_preferences.rb
+++ b/db/migrate/20210614120524_remove_user_id_from_preferences.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromPreferences < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :preferences, :user_id }
+  end
+end

--- a/db/migrate/20210614121057_add_github_user_reference_to_preferences.rb
+++ b/db/migrate/20210614121057_add_github_user_reference_to_preferences.rb
@@ -1,0 +1,5 @@
+class AddGithubUserReferenceToPreferences < ActiveRecord::Migration[6.0]
+  def change
+   safety_assured { add_reference :preferences, :github_user, foreign_key: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_02_150223) do
+ActiveRecord::Schema.define(version: 2021_06_14_121057) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,10 +147,10 @@ ActiveRecord::Schema.define(version: 2021_06_02_150223) do
     t.bigint "default_organization_id"
     t.bigint "default_team_id"
     t.bigint "default_time"
-    t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["user_id"], name: "index_preferences_on_user_id"
+    t.bigint "github_user_id"
+    t.index ["github_user_id"], name: "index_preferences_on_github_user_id"
   end
 
   create_table "pull_request_relations", force: :cascade do |t|
@@ -268,7 +268,7 @@ ActiveRecord::Schema.define(version: 2021_06_02_150223) do
   add_foreign_key "organization_memberships", "github_users"
   add_foreign_key "organization_memberships", "organizations"
   add_foreign_key "organization_syncs", "organizations"
-  add_foreign_key "preferences", "users"
+  add_foreign_key "preferences", "github_users"
   add_foreign_key "pull_request_relations", "github_users"
   add_foreign_key "pull_request_relations", "pull_requests"
   add_foreign_key "pull_request_review_requests", "github_users"

--- a/spec/factories/preferences.rb
+++ b/spec/factories/preferences.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :preference do
-    association :user
+    association :github_user
 
     default_organization_id { 1 }
     default_team_id { 1 }

--- a/spec/models/github_user_spec.rb
+++ b/spec/models/github_user_spec.rb
@@ -2,12 +2,13 @@ require 'spec_helper'
 
 RSpec.describe GithubUser, type: :model do
   describe 'validations' do
-    it { should validate_presence_of :gh_id }
-    it { should validate_presence_of :login }
+    it { is_expected.to validate_presence_of :gh_id }
+    it { is_expected.to validate_presence_of :login }
   end
 
   describe 'relationships' do
-    it { should have_many(:pull_requests) }
-    it { should have_many(:pull_request_reviews) }
+    it { is_expected.to have_many(:pull_requests) }
+    it { is_expected.to have_many(:pull_request_reviews) }
+    it { is_expected.to have_one(:preference) }
   end
 end

--- a/spec/models/preference_spec.rb
+++ b/spec/models/preference_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe Preference, type: :model do
   end
 
   describe 'relationships' do
-    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:github_user) }
   end
 end


### PR DESCRIPTION
### Contexto
En #384 se creó una relación entre el modelo `Preference` y el modelo `User`, cuando lo correcto tendría que haber sido asociarlo con el modelo `GithubUser`

### Qué se está haciendo

- Se elimina la columna `user_id` de la tabla `preferences` y se agrega una columna `github_user_id`
- Se elimina la relación del modelo `User` y se agrega al modelo `GithubUser`. También se corrige en el modelo `Preference`
- Se corrigen los tests
- *Bonus Track*: Se reemplaza `should` por `is_expected.to` en los tests de `GithubUser`