### PR TITLE
feat(review-recomendation): add format to last_review from backend

### DIFF
--- a/app/javascript/components/profile/relations.vue
+++ b/app/javascript/components/profile/relations.vue
@@ -105,12 +105,12 @@ export default {
     getTooltipMessage(user) {
       const score = user.score.toPrecision(SCORE_PRECISION);
       let lastReviewFormat = '-';
-      if (user.last_review) {
-        const lastReviewDate = new Date(user.last_review);
+      const lastReviewDate = new Date(user.lastReview);
+      if (lastReviewDate.getTime()) {
         lastReviewFormat = lastReviewDate.toLocaleDateString('es-CL', { dateStyle: 'short' });
       }
 
-      return `${user.login}\n Puntaje: ${score}\n Última revisión: ${lastReviewFormat}`;
+      return `${user.login}\n Puntaje: ${score}\n Última revisión:\n ${lastReviewFormat}`;
     },
   },
 };


### PR DESCRIPTION
## Objetivo
Formatear la última revisión desde el backend.
En la imagen se ve que la fecha no se está mostrando:
![image](https://user-images.githubusercontent.com/26175977/122576110-5b582900-d01f-11eb-96e8-e48f7aefb614.png)
Con este cambio debería mostrarse sin problemas.