### PR TITLE
create default preference on api call

### DIFF
--- a/app/controllers/api/v1/preferences_controller.rb
+++ b/app/controllers/api/v1/preferences_controller.rb
@@ -13,7 +13,13 @@ class Api::V1::PreferencesController < Api::V1::BaseController
   private
 
   def preference
-    @preference ||= github_user.preference
+    @preference ||= Preference.find_or_create_by(github_user_id: github_user.id) do |preference|
+      org_id = OrganizationMembership.find_by(github_user_id: github_user.id).organization_id
+      team_id = FroggoTeamMembership.find_by(github_user_id: github_user.id).froggo_team_id
+      preference.default_organization_id = org_id
+      preference.default_team_id = team_id
+      preference.default_time = 1
+    end
   end
 
   def github_user


### PR DESCRIPTION
### Contexto
En los PRs anteriores se movieron las preferencias de usuario al backend, a las que se puede acceder via api.
### Qué se está haciendo
Como es posible que los usuarios antiguos no tengan sus preferencias guardadas en el backend, cuando se llame a la api (tanto en show como update), si no existe una `preference` para ese `github_user`, se crea una con valores por defecto.