### PR TITLE
Preference API fixes

### DIFF
--- a/app/controllers/api/v1/preferences_controller.rb
+++ b/app/controllers/api/v1/preferences_controller.rb
@@ -14,8 +14,8 @@ class Api::V1::PreferencesController < Api::V1::BaseController
 
   def preference
     @preference ||= Preference.find_or_create_by(github_user_id: github_user.id) do |preference|
-      org_id = OrganizationMembership.find_by(github_user_id: github_user.id).organization_id
-      team_id = FroggoTeamMembership.find_by(github_user_id: github_user.id).froggo_team_id
+      org_id = OrganizationMembership.find_by(github_user_id: github_user.id)&.organization_id
+      team_id = FroggoTeamMembership.find_by(github_user_id: github_user.id)&.froggo_team_id
       preference.default_organization_id = org_id
       preference.default_team_id = team_id
       preference.default_time = 1

--- a/app/serializers/api/v1/preference_serializer.rb
+++ b/app/serializers/api/v1/preference_serializer.rb
@@ -1,3 +1,13 @@
 class Api::V1::PreferenceSerializer < ActiveModel::Serializer
-  attributes :github_user_id, :default_organization_id, :default_team_id, :default_time
+  attributes :github_user_id, :default_org, :default_team, :default_time
+
+  def default_org
+    organization = Organization.find_by(id: object.default_organization_id)
+    Api::V1::OrganizationSerializer.new(organization) if organization
+  end
+
+  def default_team
+    froggo_team = FroggoTeam.find_by(id: object.default_team_id)
+    Api::V1::FroggoTeamSerializer.new(froggo_team) if froggo_team
+  end
 end


### PR DESCRIPTION
### Contexto
Al llamar a la api de preferences, si no existe una `preference` para el usuario, se crea una con valores por defecto. Los valores por defecto incluían el id de la primera organización a la que pertenezca el usuario, y lo mismo para el froggo team, pero no contemplaban el caso en que el usuario se haya creado recién y no pertenezca a ninguna org ni team.

### Qué se está haciendo
- Si el `GithubUser` no pertenece a una `Organization`, la `preference` se crea con `org_id = nil` (análogo para `FroggoTeam`)
- En vez de mostrar el `org_id` y `team_id`, se serializan la `organization` con esa id, y lo mismo para el `froggo_team`, por conveniencia a la hora de hacer cosas en el frontend.