### PR TITLE
assignationMetric Model

### DIFF
--- a/app/models/assignation_metric.rb
+++ b/app/models/assignation_metric.rb
@@ -1,0 +1,35 @@
+class AssignationMetric < ApplicationRecord
+  belongs_to :github_user
+  belongs_to :pull_request
+
+  enum from: {
+    desktop: 0,
+    extension: 1
+  }
+
+  validates :from, presence: true
+  validates :github_user_id, uniqueness: { scope: :pull_request_id }
+end
+
+# == Schema Information
+#
+# Table name: assignation_metrics
+#
+#  id              :bigint(8)        not null, primary key
+#  from            :bigint(8)        not null
+#  github_user_id  :bigint(8)        not null
+#  pull_request_id :bigint(8)        not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+# Indexes
+#
+#  index_assignation_metrics_on_github_user_id   (github_user_id)
+#  index_assignation_metrics_on_pull_request_id  (pull_request_id)
+#  index_metrics_on_ghuser_and_pr                (github_user_id,pull_request_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (github_user_id => github_users.id)
+#  fk_rails_...  (pull_request_id => pull_requests.id)
+#

--- a/app/models/github_user.rb
+++ b/app/models/github_user.rb
@@ -15,6 +15,8 @@ class GithubUser < ApplicationRecord
   has_many :taggings, as: :taggable, dependent: :destroy
   has_many :tags, through: :taggings
 
+  has_many :assignation_metrics, dependent: :destroy
+
   has_one :preference, dependent: :destroy
 
   validates :gh_id, presence: true

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -12,6 +12,8 @@ class PullRequest < ApplicationRecord
   has_many :pull_request_relations, dependent: :destroy
   has_many :pull_request_review_requests, dependent: :destroy
 
+  has_many :assignation_metrics, dependent: :destroy
+
   scope :within_month_limit, -> do
     where('pull_requests.gh_updated_at > ?',
           Time.current - ENV['PULL_REQUEST_MONTH_LIMIT'].to_i.months)

--- a/db/migrate/20210714212330_create_assignation_metrics.rb
+++ b/db/migrate/20210714212330_create_assignation_metrics.rb
@@ -1,0 +1,12 @@
+class CreateAssignationMetrics < ActiveRecord::Migration[6.0]
+  def change
+    create_table :assignation_metrics do |t|
+      t.bigint :from, null: false
+      t.references :github_user, null: false, foreign_key: true
+      t.references :pull_request, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :assignation_metrics, [:github_user_id,:pull_request_id], unique: true, name: :index_metrics_on_ghuser_and_pr
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_14_121057) do
+ActiveRecord::Schema.define(version: 2021_07_14_212330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,17 @@ ActiveRecord::Schema.define(version: 2021_06_14_121057) do
     t.string "uid"
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
+  create_table "assignation_metrics", force: :cascade do |t|
+    t.bigint "from", null: false
+    t.bigint "github_user_id", null: false
+    t.bigint "pull_request_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["github_user_id", "pull_request_id"], name: "index_metrics_on_ghuser_and_pr", unique: true
+    t.index ["github_user_id"], name: "index_assignation_metrics_on_github_user_id"
+    t.index ["pull_request_id"], name: "index_assignation_metrics_on_pull_request_id"
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
@@ -262,6 +273,8 @@ ActiveRecord::Schema.define(version: 2021_06_14_121057) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "assignation_metrics", "github_users"
+  add_foreign_key "assignation_metrics", "pull_requests"
   add_foreign_key "froggo_team_memberships", "froggo_teams"
   add_foreign_key "froggo_team_memberships", "github_users"
   add_foreign_key "likes", "github_users"

--- a/spec/factories/assignation_metrics.rb
+++ b/spec/factories/assignation_metrics.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :assignation_metric do
+    association :github_user
+    association :pull_request
+
+    from { :desktop }
+  end
+end

--- a/spec/models/assignation_metric_spec.rb
+++ b/spec/models/assignation_metric_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe AssignationMetric, type: :model do
+  it 'has a valid factory' do
+    expect(build(:assignation_metric)).to be_valid
+  end
+
+  describe 'validations' do
+    subject { FactoryBot.build(:assignation_metric) }
+
+    it { is_expected.to validate_presence_of :from }
+    it { is_expected.to validate_uniqueness_of(:github_user_id).scoped_to(:pull_request_id) }
+  end
+
+  describe 'relationships' do
+    it { is_expected.to belong_to(:github_user) }
+    it { is_expected.to belong_to(:pull_request) }
+  end
+end

--- a/spec/models/github_user_spec.rb
+++ b/spec/models/github_user_spec.rb
@@ -10,5 +10,6 @@ RSpec.describe GithubUser, type: :model do
     it { is_expected.to have_many(:pull_requests) }
     it { is_expected.to have_many(:pull_request_reviews) }
     it { is_expected.to have_one(:preference) }
+    it { is_expected.to have_many(:assignation_metrics).dependent(:destroy) }
   end
 end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -11,5 +11,6 @@ RSpec.describe PullRequest, type: :model do
     it { is_expected.to belong_to(:owner) }
     it { is_expected.to belong_to(:merged_by).optional(true) }
     it { is_expected.to have_many(:pull_request_review_requests) }
+    it { is_expected.to have_many(:assignation_metrics).dependent(:destroy) }
   end
 end


### PR DESCRIPTION
### Contexto

El modelo `assignationMetric` trackea las asignaciones de una pr a un usuario tanto a traves de la pagina, como de la extension.

### Qué se esta haciendo

- Se agrega el modelo `AssignationMetric`, y sus relaciones con `PullRequest` y `GithubUser`, con un campo `from` que puede ser "desktop" o "extension".
- Se agregan los tests de validación y relación.


