### PR TITLE
Feat/Add api endpoint for current user data

### DIFF
--- a/app/controllers/api/v1/github_users_controller.rb
+++ b/app/controllers/api/v1/github_users_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::GithubUsersController < Api::V1::BaseController
-  before_action :authenticate_github_user, only: [:open_prs]
+  before_action :authenticate_github_user, only: [:open_prs, :logged_user]
 
   def team_review_recommendations
     response = { response: {
@@ -48,6 +48,11 @@ class Api::V1::GithubUsersController < Api::V1::BaseController
       open_prs: gh_pr_service.open_prs(gh_user.login)
     } }
     respond_with response
+  end
+
+  def logged_user
+    github_user = github_session.user
+    respond_with github_user
   end
 
   private

--- a/app/serializers/api/v1/github_user_serializer.rb
+++ b/app/serializers/api/v1/github_user_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::GithubUserSerializer < ActiveModel::Serializer
-  attributes :id, :description, :name, :tags
+  attributes :id, :description, :name, :tags, :login, :avatar_url
 
   def tags
     object.tags.map do |tag|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       end
       resources :github_users, only: [] do
         get '/open_prs' => :open_prs, on: :collection
+        get '/current' => :logged_user, on: :collection
       end
       patch 'github_users/:id' => 'github_users#update'
       get 'users/:github_login/pull_requests_information' =>

--- a/spec/controllers/api/v1/github_users_controller_spec.rb
+++ b/spec/controllers/api/v1/github_users_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::GithubUsersController, type: :controller do
+  let(:github_session) { instance_double("GithubSession") }
+
+  before do
+    allow(GithubSession).to receive(:new).and_return(github_session)
+  end
+
+  describe '#current' do
+    context 'when user is logged in' do
+      let(:user) { create(:github_user, login: "user_login") }
+
+      before do
+        allow(github_session).to receive(:valid?).and_return(true)
+        allow(github_session).to receive(:user).and_return(user)
+        get :logged_user, format: :json
+      end
+
+      it 'responds with current logged user' do
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['data']['id'].to_i).to eq(user.id)
+      end
+    end
+
+    context 'when user is not logged in' do
+      before do
+        allow(github_session).to receive(:valid?).and_return(false)
+        get :logged_user, format: :json
+      end
+
+      it 'responds with landing page' do
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Contexto
Para la extensión de Froggo se requieren algunos datos que actualmente no se pueden obtener con facilidad.

### Qué se está haciendo

* Se agregan `login` y `avatar_url` al `api/v1/GithubUserSerializer`
* Se crea el endpoint `api/v1/github_users/current` para obtener los datos del usuario loggeado

#### Info adicional
Quería llamarle `current_user` al método del controller pero se caía con eso, no cacho si es algo reservado o qué, pero se arregló cambiándole el nombre a `logged_user`