### PR TITLE
fix: recommendations view color helper

### DIFF
--- a/app/javascript/components/recommendations/team-relations.vue
+++ b/app/javascript/components/recommendations/team-relations.vue
@@ -17,7 +17,7 @@
         <div
           v-if="element.explainer"
           v-tooltip="element.tooltip"
-          :class="`my-auto h-5 w-5 rounded-full shadow-sm m-1 bg-${colorFromScore(element.score)}`"
+          :class="`my-auto h-5 w-5 rounded-full shadow-sm m-1 ${colorFromScore(element.score)}`"
         />
         <relation
           v-else

--- a/app/javascript/components/recommendations/team-table.vue
+++ b/app/javascript/components/recommendations/team-table.vue
@@ -1,9 +1,9 @@
 <template>
-  <div :class="`grid grid-flow-rows w-full text-${color}`">
+  <div :class="`grid grid-flow-rows w-full ${textColor}`">
     <div class="text-sm">
       {{ title }}
     </div>
-    <div :class="`border p-3 grid grid-flow-row gap-3 border-${color}`">
+    <div :class="`border p-3 grid grid-flow-row gap-3 ${borderColor}`">
       <div
         v-if="fetchingRecommendations"
         class="text-black text-sm text-center text-opacity-50"
@@ -25,7 +25,7 @@
         <div class="text-sm">
           {{ user.login }}
         </div>
-        <div :class="`bg-${colorFromScore(user.score)} rounded-full w-5 h-5 ml-auto mr-2`" />
+        <div :class="`${colorFromScore(user.score)} rounded-full w-5 h-5 ml-auto mr-2`" />
       </a>
     </div>
   </div>
@@ -41,10 +41,6 @@ export default {
       type: String,
       required: true,
     },
-    color: {
-      type: String,
-      default: 'gray-500',
-    },
     recommendations: {
       type: Object,
       default: () => { },
@@ -56,6 +52,20 @@ export default {
     fetchingRecommendations: {
       type: Boolean,
       default: true,
+    },
+  },
+  computed: {
+    textColor() {
+      if (this.type === 'best') return 'text-teal-500';
+      else if (this.type === 'worst') return 'text-red-500';
+
+      return 'text-black';
+    },
+    borderColor() {
+      if (this.type === 'best') return 'border-teal-500';
+      else if (this.type === 'worst') return 'border-red-500';
+
+      return 'border-black';
     },
   },
   methods: {

--- a/app/javascript/components/recommendations/team.vue
+++ b/app/javascript/components/recommendations/team.vue
@@ -4,14 +4,12 @@
       <team-table
         :fetching-recommendations="fetchingRecommendations"
         :recommendations="recommendations"
-        color="teal-500"
         type="best"
         :title="$i18n.t('message.recommendations.recommendedReviewers')"
       />
       <team-table
         :fetching-recommendations="fetchingRecommendations"
         :recommendations="recommendations"
-        color="red-500"
         type="worst"
         :title="$i18n.t('message.recommendations.notRecommendedReviewers')"
       />

--- a/app/javascript/components/relation.vue
+++ b/app/javascript/components/relation.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="relative">
     <div
-      :class="`absolute z-10 w-3 h-3 right-0 rounded-full bg-${colorFromScore(user.score)}`"
+      :class="`absolute z-10 w-3 h-3 right-0 rounded-full ${colorFromScore(user.score)}`"
     />
     <img
       :class="`h-8 w-8 rounded-full shadow`"

--- a/app/javascript/helpers/tailwind-color-from-score.js
+++ b/app/javascript/helpers/tailwind-color-from-score.js
@@ -1,14 +1,14 @@
-export default function colorFromScore(score, noColor = 'gray-500') {
+export default function colorFromScore(score, noColor = 'bg-gray-500') {
   /* eslint-disable no-magic-numbers*/
   if (score === -1.0) return noColor;
 
-  if (score <= 0.25) return 'teal-500';
-  if (score <= 0.5) return 'teal-300';
-  if (score <= 0.75) return 'teal-100';
-  if (score <= 1) return 'yellow-300';
-  if (score <= 1.25) return 'yellow-200';
-  if (score <= 1.5) return 'red-100';
-  if (score <= 1.75) return 'red-300';
+  if (score <= 0.25) return 'bg-teal-500';
+  if (score <= 0.5) return 'bg-teal-300';
+  if (score <= 0.75) return 'bg-teal-100';
+  if (score <= 1) return 'bg-yellow-300';
+  if (score <= 1.25) return 'bg-yellow-200';
+  if (score <= 1.5) return 'bg-red-100';
+  if (score <= 1.75) return 'bg-red-300';
 
-  return 'red-500';
+  return 'bg-red-500';
 }


### PR DESCRIPTION
### Contexto
En #395 se incluyo un helper de clases de tailwind para aplicar algunos colores en la vista de recomendaciones, pero se aplicaban en runtime, y no pasaban el purge.

### Qué se está haciendo

- El helper ahora devuelve la clase completa `bg-color-123`
- Las tablas de recomendaciones ahora _calculan_ el color directamente