### PR TITLE
PRs abiertas en vista de recomendaciones

### DIFF
--- a/app/assets/images/check.svg
+++ b/app/assets/images/check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/></svg>

--- a/app/assets/images/content-copy.svg
+++ b/app/assets/images/content-copy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>

--- a/app/javascript/components/recommendations/index.vue
+++ b/app/javascript/components/recommendations/index.vue
@@ -27,7 +27,9 @@
         </div>
       </div>
       <div class="mt-3">
-        <recommendations-team />
+        <recommendations-team
+          :pull-requests="pullRequests"
+        />
       </div>
     </div>
     <div
@@ -66,6 +68,10 @@ export default {
     user: {
       type: Object,
       required: true,
+    },
+    pullRequests: {
+      type: Array,
+      default: () => [],
     },
   },
   computed: mapState({

--- a/app/javascript/components/recommendations/multiselect-reviewer.vue
+++ b/app/javascript/components/recommendations/multiselect-reviewer.vue
@@ -1,0 +1,128 @@
+<template>
+  <div class="flex">
+    <multiselect
+      track-by="login"
+      label="login"
+      v-model="selectedReviewers"
+      :options="reviewers"
+      :searchable="true"
+      :multiple="true"
+      :close-on-select="false"
+      :clear-on-select="false"
+      :show-labels="false"
+      placeholder="Revisores"
+    >
+      <template #option="props">
+        <div class="flex flex-row">
+          <relation
+            :user="props.option"
+          />
+          <div class="flex flex-col ml-3 text-black item justify-between">
+            <div>{{ props.option.login }}</div>
+            <div
+              v-if="!props.option.tags.length"
+              class="mt-3 text-xs text-gray-500"
+            >
+              <i>{{ $i18n.t('message.recommendations.noTags') }}</i>
+            </div>
+            <div
+              v-else
+              class="flex flex-wrap h-min-12"
+            >
+              <div
+                v-for="tag in props.option.tags"
+                :key="tag.name"
+              >
+                <div class="div bg-blue-900 rounded-full p-3 mt-2 mr-2 text-white">
+                  {{ tag.name }}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+      <template #caret="{ toggle }">
+        <div
+          class="absolute right-0 p-2 my-auto"
+          @mousedown.prevent.stop="toggle"
+        >
+          <inline-svg
+            :src="require('../../../assets/images/chevron-down.svg').default"
+            class="text-black fill-current h-6 w-6 ml-2"
+          />
+        </div>
+      </template>
+      <template #noOptions="{ toggle }">
+        <div
+          class="absolute right-0 p-2 my-auto"
+          @mousedown.prevent.stop="toggle"
+        >
+          {{ $i18n.t('message.recommendations.noReviewersAvalaible') }}
+        </div>
+      </template>
+    </multiselect>
+    <button
+      :class="`rounded-r-lg border-r border-t border-b p-3 text-black
+      ${ selectedReviewers.length ? 'text-opacity-100' : 'text-opacity-50'}`"
+      @click="sendReviewers"
+    >
+      {{ $i18n.t('message.recommendations.assignReviewers') }}
+    </button>
+  </div>
+</template>
+<script>
+
+import Multiselect from 'vue-multiselect';
+import relation from '../relation.vue';
+import pullRequestReviewersApi from '../../api/pull_request_reviewers';
+
+export default {
+  components: {
+    Multiselect,
+    relation,
+  },
+  data() {
+    return {
+      selectedReviewers: [],
+    };
+  },
+  props: {
+    reviewers: {
+      type: Array,
+      default: () => [],
+    },
+    pullRequest: {
+      type: Object,
+      default: () => {},
+    },
+  },
+  methods: {
+    async sendReviewers() {
+      await Promise.all(this.selectedReviewers.map(async (reviewer, i) => {
+        const data = { reviewer: reviewer.login, pullRequestId: this.pullRequest.id };
+        const params = await pullRequestReviewersApi.addReviewer(data);
+
+        this.$emit('newReviewer', params.data.data.id);
+        this.selectedReviewers[i] = null;
+      }));
+      this.selectedReviewers = this.selectedReviewers.filter(item => item !== null);
+    },
+  },
+};
+</script>
+
+<style src="vue-multiselect/dist/vue-multiselect.min.css"></style>
+<style lang="scss">
+.multiselect {
+
+  @apply rounded-l-lg py-1 border;
+
+  &__tags {
+    @apply border-0 pl-3 rounded-lg;
+  }
+  &__placeholder {
+    @apply text-base text-black;
+  }
+
+}
+</style>

--- a/app/javascript/components/recommendations/open-pr.vue
+++ b/app/javascript/components/recommendations/open-pr.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="grid grid-cols-12 p-3">
+    <div class="col-span-4 flex flex-col justify-around pl-2">
+      <div class="text-sm font-bold flex items-center">
+        <inline-svg
+          :src="require('assets/images/pull-request.svg').default"
+          class="text-back fill-current h-6 w-6  mr-2"
+        />
+        {{ pullRequest.pull_request.title }}
+        <button
+          class="ml-2"
+          @click="copyPrUrl()"
+        >
+          <inline-svg
+            :src="require(`assets/images/${ copied ? 'check' : 'content-copy'}.svg`).default"
+            class="w-4 h-4 fill-current"
+          />
+        </button>
+      </div>
+      <div class="text-sm text-gray-500">
+        {{ prDate(pullRequest.pull_request.created_at) }}
+      </div>
+    </div>
+    <div class="col-span-2 flex flex-row items-center justify-end ml-3 text-sm">
+      <div
+        v-if="!pullRequest.reviewers.length"
+      >
+        <i>{{ $i18n.t('message.recommendations.noReviewers') }}</i>
+      </div>
+      <div
+        v-else
+        v-for="reviewer in reviewers"
+        :key="reviewer.id"
+        class="relative ml-2 py-0"
+      >
+        <img
+          :class="`h-8 w-8 rounded-full shadow`"
+          :src="reviewer.avatar_url"
+        >
+        <a
+          class="absolute h-full w-full top-0 z-10"
+          :href="`/users/${reviewer.id}`"
+        />
+      </div>
+    </div>
+    <div class="col-span-6 p-3">
+      <multiselect-reviewer
+        :reviewers="avalaibleReviewers(recommendations.all, reviewers)"
+        :pull-request="pullRequest.pull_request"
+        @newReviewer="appendReviewer"
+      />
+    </div>
+  </div>
+</template>
+<script>
+
+import moment from 'moment';
+import multiselectReviewer from './multiselect-reviewer.vue';
+
+const COPY_TIMEOUT_IN_MS = 3000;
+
+export default {
+  components: { multiselectReviewer },
+  props: {
+    pullRequest: {
+      type: Object,
+      default: () => {},
+    },
+    recommendations: {
+      type: Object,
+      default: () => {},
+    },
+  },
+  data() {
+    return {
+      copied: false,
+      currentTimeout: null,
+      reviewers: this.pullRequest.reviewers,
+    };
+  },
+  methods: {
+    clearCopyTimeout() {
+      if (this.currentTimeout) {
+        clearTimeout(this.currentTimeout);
+      }
+    },
+    setCopyTimeout() {
+      this.copied = true;
+      this.currentTimeout = setTimeout(() => {
+        this.copied = false;
+      }, COPY_TIMEOUT_IN_MS);
+    },
+    async copyPrUrl() {
+      this.clearCopyTimeout();
+      this.setCopyTimeout();
+      await navigator.clipboard.writeText(this.pullRequest.pull_request.html_url);
+    },
+    prDate(date) {
+      return moment(date).locale(this.$i18n.locale).fromNow();
+    },
+    avalaibleReviewers(teamMembers, reviewers) {
+      return teamMembers.filter((element) =>
+        !reviewers.some((reviewer) => reviewer.id === element.id),
+      );
+    },
+    appendReviewer(reviewer) {
+      this.reviewers.push(this.recommendations.all.find(item => item.id === parseInt(reviewer, 10)));
+    },
+  },
+};
+</script>

--- a/app/javascript/components/recommendations/open-prs.vue
+++ b/app/javascript/components/recommendations/open-prs.vue
@@ -1,0 +1,59 @@
+<template>
+  <div>
+    <div
+      v-if="fetchingRecommendations "
+      class="text-black text-sm text-center text-opacity-50"
+    >
+      {{ $i18n.t('message.recommendations.loading') }}
+    </div>
+    <div v-else>
+      <div
+        v-if="!pullRequests.length"
+        class="rounded border p-3 text-sm text-black text-opacity-25 text-center"
+      >
+        <i>{{ $i18n.t('message.recommendations.noPullRequests') }}</i>
+      </div>
+      <div
+        v-else
+        class="border rounded-t-lg grid grid-flow-row divide-y"
+      >
+        <div class="p-4 text-sm">
+          {{ $i18n.t('message.recommendations.openPullRequests') }} ({{ pullRequests.length }})
+        </div>
+        <div
+          v-for="pullRequest in pullRequests"
+          :key="pullRequest.id"
+        >
+          <open-pr
+            :pull-request="pullRequest"
+            :recommendations="recommendations"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+import openPr from './open-pr.vue';
+
+export default {
+  components: { openPr },
+  props: {
+    fetchingRecommendations: {
+      type: Boolean,
+      default: true,
+    },
+    recommendations: {
+      type: Object,
+      default: () => {},
+    },
+    pullRequests: {
+      type: Array,
+      default: () => [],
+    },
+  },
+};
+</script>
+

--- a/app/javascript/components/recommendations/team.vue
+++ b/app/javascript/components/recommendations/team.vue
@@ -22,6 +22,11 @@
         :recommendations="recommendations"
       />
     </div>
+    <open-prs
+      :fetching-recommendations="fetchingRecommendations"
+      :recommendations="recommendations"
+      :pull-requests="pullRequests"
+    />
   </div>
   <div
     v-else
@@ -37,11 +42,19 @@ import { mapState } from 'vuex';
 
 import TeamTable from './team-table.vue';
 import TeamRelations from './team-relations.vue';
+import OpenPrs from './open-prs.vue';
 
 export default {
+  props: {
+    pullRequests: {
+      type: Array,
+      default: () => [],
+    },
+  },
   components: {
     TeamTable,
     TeamRelations,
+    OpenPrs,
   },
   computed: mapState({
     recommendations: state => state.recommendations.recommendations,

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -132,6 +132,12 @@ export default {
       noTeamsInOrganization: 'You are not member of any organization team so you have no recommendations',
       noOrganizations: 'No organizations',
       noTeams: 'No teams',
+      openPullRequests: 'Open pull requests',
+      noReviewers: 'No reviewers',
+      assignReviewers: 'assign',
+      noPullRequests: 'There are not open pull requests',
+      noTags: 'No tags...',
+      noReviewersAvalaible: 'No reviewers avalaible',
     },
     global: {
       header: {

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -134,6 +134,12 @@ export default {
       noTeamsInOrganization: 'Aún no perteneces a un equipo en esta organización',
       noOrganizations: 'Aún no perteneces a ninguna organización',
       noTeams: 'Sin equipos',
+      openPullRequests: 'Pull requests abiertas',
+      noReviewers: 'Sin revisores',
+      assignReviewers: 'asignar',
+      noPullRequests: 'No hay pull requests abiertas',
+      noTags: 'No tiene tags...',
+      noReviewersAvalaible: 'No hay revisores disponibles',
     },
     global: {
       header: {

--- a/app/serializers/pull_request_serializer.rb
+++ b/app/serializers/pull_request_serializer.rb
@@ -1,0 +1,4 @@
+class PullRequestSerializer < ActiveModel::Serializer
+  attributes :id, :title, :repository_name, :owner_id, :html_url, :created_at,
+             :owner_name, :description, :commits, :owner_login
+end

--- a/app/views/recommendations/show.html.erb
+++ b/app/views/recommendations/show.html.erb
@@ -2,4 +2,5 @@
  :teams="<%= @teams.to_json %>"
  :timespans="<%= timespans_options_with_name.to_json %>"
  :user="<%= GithubUserSerializer.new(@github_session.user).to_json %>"
+ :pull-requests="<%= @open_prs %>"
  />

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "vue-horizontal": "^0.8.10",
     "vue-horizontal-list": "^1.0.12",
     "vue-i18n": "^7.4.0",
+    "vue-multiselect": "^2.1.6",
     "vue-loader": "^15.9.2",
     "vue-inline-svg": "^2.0.0",
     "vue-select": "^3.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10848,6 +10848,11 @@ vue-loader@^15.9.2:
     vue-hot-reload-api "^2.3.0"
     vue-style-loader "^4.1.0"
 
+vue-multiselect@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/vue-multiselect/-/vue-multiselect-2.1.6.tgz#5be5d811a224804a15c43a4edbb7485028a89c7f"
+  integrity sha512-s7jmZPlm9FeueJg1RwJtnE9KNPtME/7C8uRWSfp9/yEN4M8XcS/d+bddoyVwVnvFyRh9msFo0HWeW0vTL8Qv+w==
+
 vue-resize@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/vue-resize/-/vue-resize-0.4.5.tgz#4777a23042e3c05620d9cbda01c0b3cc5e32dcea"


### PR DESCRIPTION
### Contexto
El rediseño de la página de recomendaciones de Froggo incluye las prs abiertas, sus revisores asignados, y la posibilidad de asignar un revisor a cada pr.

https://www.figma.com/file/ZZvsjJJIkiHhX8NRVxRuXV/Froggo?node-id=598%3A11

### Qué se está haciendo

- Se agregan los componentes `open_pr`, `open_prs` y `multiselect-reviewer`, a la vista de recomendaciones
 
#### En particular hay que revisar
- La funcion `serialized_open_prs` de `recommendations_controller`. La estructura de `open_prs` es:

        [ 
          {
            pull_request: PullRequest, 
            reviewers: [GithubUser, ...] 
          }, ...
        ]

Existe otra forma de aplicar el serializer que corresponde a cada modelo `PullRequest` y `GithubUser` dentro de `open_prs`?

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
![image](https://user-images.githubusercontent.com/28970593/127962254-f81edcf3-696c-43c0-9a5f-1e20661d379b.png)
![image](https://user-images.githubusercontent.com/28970593/127962316-05db957b-b65a-4f5a-b950-816f9729081d.png)
