### PR TITLE
Fix tooltips and space for reviewers in recommendations view

### DIFF
--- a/app/javascript/components/recommendations/open-pr.vue
+++ b/app/javascript/components/recommendations/open-pr.vue
@@ -1,46 +1,48 @@
 <template>
   <div class="grid grid-cols-12 p-3">
-    <div class="col-span-4 flex flex-col justify-around pl-2">
-      <div class="text-sm font-bold flex items-center">
-        <inline-svg
-          :src="require('assets/images/pull-request.svg').default"
-          class="text-back fill-current h-6 w-6  mr-2"
-        />
-        {{ pullRequest.pull_request.title }}
-        <button
-          class="ml-2"
-          @click="copyPrUrl()"
-        >
+    <div class="col-span-6 flex justify-between">
+      <div class="flex flex-col justify-around pl-2">
+        <div class="text-sm font-bold flex items-center">
           <inline-svg
-            :src="require(`assets/images/${ copied ? 'check' : 'content-copy'}.svg`).default"
-            class="w-4 h-4 fill-current"
+            :src="require('assets/images/pull-request.svg').default"
+            class="text-back fill-current h-6 w-6  mr-2"
           />
-        </button>
+          {{ pullRequest.pull_request.title }}
+          <button
+            class="ml-2"
+            @click="copyPrUrl()"
+          >
+            <inline-svg
+              :src="require(`assets/images/${ copied ? 'check' : 'content-copy'}.svg`).default"
+              class="w-4 h-4 fill-current"
+            />
+          </button>
+        </div>
+        <div class="text-sm text-gray-500">
+          {{ prDate(pullRequest.pull_request.created_at) }}
+        </div>
       </div>
-      <div class="text-sm text-gray-500">
-        {{ prDate(pullRequest.pull_request.created_at) }}
-      </div>
-    </div>
-    <div class="col-span-2 flex flex-row items-center justify-end ml-3 text-sm">
-      <div
-        v-if="!pullRequest.reviewers.length"
-      >
-        <i>{{ $i18n.t('message.recommendations.noReviewers') }}</i>
-      </div>
-      <div
-        v-else
-        v-for="reviewer in reviewers"
-        :key="reviewer.id"
-        class="relative ml-2 py-0"
-      >
-        <img
-          :class="`h-8 w-8 rounded-full shadow`"
-          :src="reviewer.avatar_url"
+      <div class="flex flex-row flex-grow items-center justify-end ml-3 text-sm">
+        <div
+          v-if="!pullRequest.reviewers.length"
         >
-        <a
-          class="absolute h-full w-full top-0 z-10"
-          :href="`/users/${reviewer.id}`"
-        />
+          <i>{{ $i18n.t('message.recommendations.noReviewers') }}</i>
+        </div>
+        <div
+          v-else
+          v-for="reviewer in reviewers"
+          :key="reviewer.id"
+          class="relative ml-2 py-0 h-8 w-8 "
+        >
+          <img
+            :class="`rounded-full shadow`"
+            :src="reviewer.avatar_url"
+          >
+          <a
+            class="absolute h-full w-full top-0 z-10"
+            :href="`/users/${reviewer.id}`"
+          />
+        </div>
       </div>
     </div>
     <div class="col-span-6 p-3">

--- a/app/javascript/components/recommendations/team-relations.vue
+++ b/app/javascript/components/recommendations/team-relations.vue
@@ -12,16 +12,20 @@
       <section
         v-for="element in allRelationsBadges"
         :key="element.id"
-        class="mx-1 py-1"
       >
         <div
           v-if="element.explainer"
-          v-tooltip="element.tooltip"
-          :class="`my-auto h-5 w-5 rounded-full shadow-sm m-1 ${colorFromScore(element.score)}`"
-        />
+          v-tooltip.top="element.tooltip"
+          class="h-8 w-8 flex"
+        >
+          <div
+            :class="`my-auto h-5 w-5 rounded-full shadow-sm m-1 ${colorFromScore(element.score)}`"
+          />
+        </div>
         <relation
           v-else
           :user="element"
+          class="mx-1 my-1"
         />
       </section>
     </vue-horizontal>


### PR DESCRIPTION
### Contexto
En Froggo estamos desarrollando la nueva pagina de recomendaciones:

https://www.figma.com/file/ZZvsjJJIkiHhX8NRVxRuXV/Froggo?node-id=598%3A11

Con la ultima pr quedaron dos bugs que esta pr soluciona:

- Si una pr tiene muchos reviewers, las fotos de los reviewers se _achican_ para caber en el espacio.
- Los tooltip de los _circulitos de colores_  en `team-relations` no funcionan.

### Que se esta haciendo

- Se permite que el espacio que ocupan las fotos de los reviewers de una pr pueda agrandarse (`flex-grow`), y ocupar espacio que normalmente ocuparia el titulo de la pr.
- El bug de los tooltip encima de los _circulitos de colores_ en `team_relations`, esta parcialmente solucionado. El problema viene de incluir `v-tooltip` dentro de `vue-horizontal`, y solucionarlo implica probablemente reescribir la libreria.
