### PR TITLE
Assign multiple reviewers at once

### DIFF
--- a/app/javascript/components/recommendations/multiselect-reviewer.vue
+++ b/app/javascript/components/recommendations/multiselect-reviewer.vue
@@ -98,14 +98,10 @@ export default {
   },
   methods: {
     async sendReviewers() {
-      await Promise.all(this.selectedReviewers.map(async (reviewer, i) => {
-        const data = { reviewer: reviewer.login, pullRequestId: this.pullRequest.id };
-        const params = await pullRequestReviewersApi.addReviewer(data);
-
-        this.$emit('newReviewer', params.data.data.id);
-        this.selectedReviewers[i] = null;
-      }));
-      this.selectedReviewers = this.selectedReviewers.filter(item => item !== null);
+      const data = { reviewer: this.selectedReviewers.map(user => user.login), pullRequestId: this.pullRequest.id };
+      const params = await pullRequestReviewersApi.addReviewer(data);
+      this.$emit('newReviewer', params.data.data);
+      this.selectedReviewers = [];
     },
   },
 };

--- a/app/javascript/components/recommendations/open-pr.vue
+++ b/app/javascript/components/recommendations/open-pr.vue
@@ -105,8 +105,11 @@ export default {
         !reviewers.some((reviewer) => reviewer.id === element.id),
       );
     },
-    appendReviewer(reviewer) {
-      this.reviewers.push(this.recommendations.all.find(item => item.id === parseInt(reviewer, 10)));
+    appendReviewer(reviewers) {
+      this.reviewers = [];
+      reviewers.forEach(reviewer => {
+        this.reviewers.push({ id: parseInt(reviewer.id, 10), ...reviewer.attributes });
+      });
     },
   },
 };

--- a/app/javascript/components/recommendations/open-pr.vue
+++ b/app/javascript/components/recommendations/open-pr.vue
@@ -7,7 +7,7 @@
             :src="require('assets/images/pull-request.svg').default"
             class="text-back fill-current h-6 w-6  mr-2"
           />
-          {{ pullRequest.pull_request.title }}
+          {{ pullRequest.pullRequest.title }}
           <button
             class="ml-2"
             @click="copyPrUrl()"
@@ -19,12 +19,12 @@
           </button>
         </div>
         <div class="text-sm text-gray-500">
-          {{ prDate(pullRequest.pull_request.created_at) }}
+          {{ prDate(pullRequest.pullRequest.createdAt) }}
         </div>
       </div>
       <div class="flex flex-row flex-grow items-center justify-end ml-3 text-sm">
         <div
-          v-if="!pullRequest.reviewers.length"
+          v-if="!reviewers.length"
         >
           <i>{{ $i18n.t('message.recommendations.noReviewers') }}</i>
         </div>
@@ -36,7 +36,7 @@
         >
           <img
             :class="`rounded-full shadow`"
-            :src="reviewer.avatar_url"
+            :src="reviewer.avatarUrl"
           >
           <a
             class="absolute h-full w-full top-0 z-10"
@@ -48,7 +48,7 @@
     <div class="col-span-6 p-3">
       <multiselect-reviewer
         :reviewers="avalaibleReviewers(recommendations.all, reviewers)"
-        :pull-request="pullRequest.pull_request"
+        :pull-request="pullRequest.pullRequest"
         @newReviewer="appendReviewer"
       />
     </div>
@@ -95,7 +95,7 @@ export default {
     async copyPrUrl() {
       this.clearCopyTimeout();
       this.setCopyTimeout();
-      await navigator.clipboard.writeText(this.pullRequest.pull_request.html_url);
+      await navigator.clipboard.writeText(this.pullRequest.pullRequest.htmlUrl);
     },
     prDate(date) {
       return moment(date).locale(this.$i18n.locale).fromNow();

--- a/app/models/assignation_metric.rb
+++ b/app/models/assignation_metric.rb
@@ -8,7 +8,6 @@ class AssignationMetric < ApplicationRecord
   }
 
   validates :from, presence: true
-  validates :github_user_id, uniqueness: { scope: :pull_request_id }
 end
 
 # == Schema Information
@@ -26,7 +25,6 @@ end
 #
 #  index_assignation_metrics_on_github_user_id   (github_user_id)
 #  index_assignation_metrics_on_pull_request_id  (pull_request_id)
-#  index_metrics_on_ghuser_and_pr                (github_user_id,pull_request_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/views/recommendations/show.html.erb
+++ b/app/views/recommendations/show.html.erb
@@ -2,5 +2,5 @@
  :teams="<%= @teams.to_json %>"
  :timespans="<%= timespans_options_with_name.to_json %>"
  :user="<%= GithubUserSerializer.new(@github_session.user).to_json %>"
- :pull-requests="<%= @open_prs %>"
+ :pull-requests="<%= @open_prs %> | camelizeKeys"
  />

--- a/db/migrate/20210820142240_remove_unique_index_from_assignation_metric.rb
+++ b/db/migrate/20210820142240_remove_unique_index_from_assignation_metric.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueIndexFromAssignationMetric < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :assignation_metrics, name: :index_metrics_on_ghuser_and_pr, column: [:github_user_id,:pull_request_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_14_212330) do
+ActiveRecord::Schema.define(version: 2021_08_20_142240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,7 +54,6 @@ ActiveRecord::Schema.define(version: 2021_07_14_212330) do
     t.bigint "pull_request_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["github_user_id", "pull_request_id"], name: "index_metrics_on_ghuser_and_pr", unique: true
     t.index ["github_user_id"], name: "index_assignation_metrics_on_github_user_id"
     t.index ["pull_request_id"], name: "index_assignation_metrics_on_pull_request_id"
   end

--- a/spec/models/assignation_metric_spec.rb
+++ b/spec/models/assignation_metric_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe AssignationMetric, type: :model do
     subject { FactoryBot.build(:assignation_metric) }
 
     it { is_expected.to validate_presence_of :from }
-    it { is_expected.to validate_uniqueness_of(:github_user_id).scoped_to(:pull_request_id) }
   end
 
   describe 'relationships' do


### PR DESCRIPTION
### Contexto
En Froggo queremos medir cuanto se usa la plataforma y para eso implementamos el modelo AssignationMetric, el cual se creaba una vez por cada persona que asigno a una PR. Esto resultó no ser tan util, ya que asignar a 5 personas a una misma PR podia inflar las métricas, asi que decidimos medir cuantas veces se usa la plataforma, o cuantas veces se hace click en "asignar". Para eso se tuvo que implementar el poder asignar varios revisores "de una sola vez"  a una pr.

### Que se esta haciendo

- El endpoint para asignar revisores soporta un arreglo de usuarios para asignarlos todos de una vez.
- El modelo AssignationMetric relaciona el usuario de Froggo con una Pr.
- Se soluciona un pequeño bug que no mostraba las imagenes de los asignados, con `camelizeKeys`
