### PR TITLE
Refactor/profile view

### DIFF
--- a/app/assets/images/icons/close-icon.svg
+++ b/app/assets/images/icons/close-icon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41Z" fill="#38405F"/>
+</svg>

--- a/app/javascript/components/profile-card.vue
+++ b/app/javascript/components/profile-card.vue
@@ -42,18 +42,31 @@
           :teams="teams"
         />
       </div>
+      <div
+        class="flex flex-col py-10"
+        v-if="canEdit"
+      >
+        <configuration
+          :github-user="githubUser"
+          :github-session="githubSession"
+          :teams="teams"
+          :timespans="timespans"
+        />
+      </div>
     </div>
   </div>
 </template>
 
 <script>
-import Teams from './profile/teams.vue';
+import Configuration from './profile/configuration.vue';
 import Info from './profile/info.vue';
+import Teams from './profile/teams.vue';
 
 export default {
   components: {
-    Teams,
+    Configuration,
     Info,
+    Teams,
   },
   props: {
     githubUser: {
@@ -68,6 +81,10 @@ export default {
       type: Array,
       default: () => {},
     },
+    timespans: {
+      type: Array,
+      required: true,
+    },
     tags: {
       type: Array,
       required: true,
@@ -78,26 +95,8 @@ export default {
     },
   },
   data() {
-    const init = {
-      user: this.githubUser,
-      editDescription: false,
-      form: {
-        description: '',
-      },
-      readMoreActivated: true,
-      errors: '',
-      maxLength: 160,
-      error: false,
-    };
-    if (this.githubUser.description) {
-      if (this.githubUser.description.length > init.maxLength) {
-        init.readMoreActivated = false;
-      }
-      init.form.description = init.user.description;
-    }
-
     return {
-      ...init,
+      canEdit: this.githubSession.user.id === this.githubUser.id,
     };
   },
 };

--- a/app/javascript/components/profile-card.vue
+++ b/app/javascript/components/profile-card.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="grid grid-cols-8 px-14 font-sans">
+    <div class="col-span-2">
+      <div class="flex flex-col items-center">
+        <img
+          :src="githubUser.avatarUrl"
+          class="rounded-full w-48 h-48 mb-4"
+        >
+        <div class="flex flex-col items-center text-base">
+          <p class="mb-4">
+            {{ githubUser.name || t('messages.profile.no_name') }}
+          </p>
+
+          <a
+            target="_blank"
+            :href="githubUser.htmlUrl"
+            class="flex items-center"
+          >
+            <img
+              class="w-6 mr-1.5"
+              src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+            >
+            <span>
+              @{{ githubUser.login }}
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+    <div class="col-span-6 divide-y divide-gray-400 divide-solid">
+      <div class="flex flex-col pb-10">
+        <div class="flex flex-row justify-between">
+          <p class="text-lg font-semibold mb-6">
+            Mis datos
+          </p>
+        </div>
+        <p class="text-sm font-semibold mb-1">
+          Acerca de mí
+        </p>
+        <p class="mb-4">
+          {{ githubUser.description }}
+        </p>
+        <p class="text-sm font-semibold mb-1">
+          Mis tags
+        </p>
+        <div class="flex flex-row items-center">
+          <div
+            v-for="tag in userTags"
+            :key="tag.id"
+            class="px-3 py-2 bg-red-500 rounded-full text-white mr-2"
+          >
+            {{ tag.name }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    githubUser: {
+      type: Object,
+      required: true,
+    },
+    githubSession: {
+      type: Object,
+      required: true,
+    },
+    tags: {
+      type: Array,
+      required: true,
+    },
+    userTags: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    const init = {
+      user: this.githubUser,
+      editDescription: false,
+      form: {
+        description: '',
+      },
+      readMoreActivated: true,
+      errors: '',
+      maxLength: 160,
+      error: false,
+    };
+    if (this.githubUser.description) {
+      if (this.githubUser.description.length > init.maxLength) {
+        init.readMoreActivated = false;
+      }
+      init.form.description = init.user.description;
+    }
+
+    return {
+      ...init,
+    };
+  },
+};
+</script>

--- a/app/javascript/components/profile-card.vue
+++ b/app/javascript/components/profile-card.vue
@@ -29,37 +29,32 @@
     </div>
     <div class="col-span-6 divide-y divide-gray-400 divide-solid">
       <div class="flex flex-col pb-10">
-        <div class="flex flex-row justify-between">
-          <p class="text-lg font-semibold mb-6">
-            Mis datos
-          </p>
-        </div>
-        <p class="text-sm font-semibold mb-1">
-          Acerca de mí
-        </p>
-        <p class="mb-4">
-          {{ githubUser.description }}
-        </p>
-        <p class="text-sm font-semibold mb-1">
-          Mis tags
-        </p>
-        <div class="flex flex-row items-center">
-          <div
-            v-for="tag in userTags"
-            :key="tag.id"
-            class="px-3 py-2 bg-red-500 rounded-full text-white mr-2"
-          >
-            {{ tag.name }}
-          </div>
-        </div>
+        <info
+          :github-user="githubUser"
+          :github-session="githubSession"
+          :user-tags="userTags"
+        />
+      </div>
+      <div class="flex flex-col py-10">
+        <teams
+          :github-user="githubUser"
+          :github-session="githubSession"
+          :teams="teams"
+        />
       </div>
     </div>
   </div>
 </template>
 
 <script>
+import Teams from './profile/teams.vue';
+import Info from './profile/info.vue';
 
 export default {
+  components: {
+    Teams,
+    Info,
+  },
   props: {
     githubUser: {
       type: Object,
@@ -68,6 +63,10 @@ export default {
     githubSession: {
       type: Object,
       required: true,
+    },
+    teams: {
+      type: Array,
+      default: () => {},
     },
     tags: {
       type: Array,

--- a/app/javascript/components/profile-card.vue
+++ b/app/javascript/components/profile-card.vue
@@ -1,38 +1,37 @@
 <template>
-  <div class="grid grid-cols-8 px-14 font-sans">
-    <div class="col-span-2">
-      <div class="flex flex-col items-center">
-        <img
-          :src="githubUser.avatarUrl"
-          class="rounded-full w-48 h-48 mb-4"
-        >
-        <div class="flex flex-col items-center text-base">
-          <p class="mb-4">
-            {{ githubUser.name || t('messages.profile.no_name') }}
-          </p>
+  <div class="flex flex-col items-center lg:flex-row xl:flex-row lg:items-start xl:items-start px-14 font-sans">
+    <div class="flex flex-col items-center w-full overflow-x-auto lg:w-1/4 xl:w-1/4 mx-8 mb-8">
+      <img
+        :src="githubUser.avatarUrl"
+        class="rounded-full w-48 h-48 mb-4"
+      >
+      <div class="flex flex-col items-center text-base">
+        <p class="mb-4">
+          {{ githubUser.name || t('messages.profile.no_name') }}
+        </p>
 
-          <a
-            target="_blank"
-            :href="githubUser.htmlUrl"
-            class="flex items-center"
+        <a
+          target="_blank"
+          :href="githubUser.htmlUrl"
+          class="flex items-center"
+        >
+          <img
+            class="w-6 mr-1.5"
+            src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
           >
-            <img
-              class="w-6 mr-1.5"
-              src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
-            >
-            <span>
-              @{{ githubUser.login }}
-            </span>
-          </a>
-        </div>
+          <span>
+            @{{ githubUser.login }}
+          </span>
+        </a>
       </div>
     </div>
-    <div class="col-span-6 divide-y divide-gray-400 divide-solid">
+    <div class="w-3/4 divide-y divide-gray-400 divide-solid">
       <div class="flex flex-col pb-10">
-        <info
+        <information
           :github-user="githubUser"
           :github-session="githubSession"
           :user-tags="userTags"
+          :tags="tags"
         />
       </div>
       <div class="flex flex-col py-10">
@@ -48,7 +47,6 @@
       >
         <configuration
           :github-user="githubUser"
-          :github-session="githubSession"
           :teams="teams"
           :timespans="timespans"
         />
@@ -59,13 +57,13 @@
 
 <script>
 import Configuration from './profile/configuration.vue';
-import Info from './profile/info.vue';
+import Information from './profile/information.vue';
 import Teams from './profile/teams.vue';
 
 export default {
   components: {
     Configuration,
-    Info,
+    Information,
     Teams,
   },
   props: {

--- a/app/javascript/components/profile-description.vue
+++ b/app/javascript/components/profile-description.vue
@@ -96,9 +96,7 @@ export default {
       init.form.description = init.user.description;
     }
 
-    return {
-      ...init,
-    };
+    return { ...init };
   },
 };
 </script>

--- a/app/javascript/components/profile-description.vue
+++ b/app/javascript/components/profile-description.vue
@@ -1,120 +1,75 @@
 <template>
   <div>
     <div
-      v-if="user.description"
-      class="profile-info__description"
+      class="flex flex-row justify-between mb-1"
     >
+      <p class="text-sm font-semibold">
+        Acerca de mí
+      </p>
       <div
-        v-if="!readMoreActivated && !editDescription"
+        v-if="$parent.isEditing"
       >
-        <p
-          class="profile-info__user-description"
-          @dblclick="edit"
+        <froggo-button
+          v-if="descriptionChanged"
+          @click="submit"
+          variant="green"
         >
-          {{ user.description.slice(0,160) }} ...
-        </p>
-        <button
-          @click="activateReadMore"
-          class="btn-description"
-        >
-          Ver más
-        </button>
-      </div>
-      <div
-        v-if="readMoreActivated && !editDescription"
-      >
-        <p
-          @dblclick="edit"
-          class="profile-info__user-description"
-          v-html="this.user.description"
+          Guardar
+        </froggo-button>
+        <div
+          v-else
+          class="h-8"
         />
-        <button
-          v-if="user.description.length>160"
-          @click="deactivateReadMore"
-          class="btn-description"
-        >
-          Ver menos
-        </button>
       </div>
-      <p
-        v-if="error"
-        class="error"
-      >
-        Error: {{ this.errors }}
-      </p>
-      <textarea
-        v-if="editDescription"
-        name="description"
-        type="text"
-        class="input-description"
-        v-model="form.description"
-      />
-      <input
-        v-if="editDescription"
-        type="submit"
-        class="btn-description"
-        @click="submit"
-        value="Guardar"
-      >
-      <input
-        v-if="editDescription"
-        type="submit"
-        class="btn-description"
-        @click="cancel"
-        value="Cancelar"
-      >
     </div>
-
     <div
-      v-else-if="user.id == githubSession.user.id"
-      class="profile-info__description"
+      v-if="!$parent.isEditing"
     >
       <p
-        v-if="error"
-        class="error"
-      >
-        Error: {{ this.errors }}
-      </p>
+        v-html="this.user.description"
+      />
+    </div>
+    <div
+      v-else-if="$parent.isEditing"
+      class="flex flex-row"
+    >
       <textarea
         name="description"
         type="text"
         placeholder="Agrega una descripción de máximo 255 caracteres"
-        class="input-description"
+        class="flex flex-grow resize-none border rounded w-full p-2"
         v-model="form.description"
       />
-      <input
-        type="submit"
-        class="btn-description"
-        @click="submit"
-        value="Guardar"
-      >
     </div>
+    <p
+      v-if="error"
+    >
+      Error: {{ this.errors }}
+    </p>
   </div>
 </template>
 
 <script>
+
 import usersApi from '../api/users';
+import FroggoButton from './shared/froggo-button.vue';
 
 export default {
-
+  components: {
+    FroggoButton,
+  },
   props: {
     githubUser: {
       type: Object,
       required: true,
     },
-    githubSession: {
-      type: Object,
-      required: true,
+  },
+  computed: {
+    descriptionChanged() {
+      return this.form.description !== this.user.description;
     },
   },
-
   methods: {
-    activateReadMore() {
-      this.readMoreActivated = true;
-    },
-    deactivateReadMore() {
-      this.readMoreActivated = false;
-    },
     submit() {
       usersApi.updateUser(this.githubUser.id, this.form)
         // eslint-disable-next-line max-statements
@@ -122,40 +77,22 @@ export default {
           this.user = res.data.data.attributes;
           this.error = false;
           this.form.description = this.user.description;
-          this.readMoreActivated = this.user.description.length <= this.maxLength;
-          this.editDescription = false;
         }).catch(() => {
           this.error = true;
-          this.errors = 'Descripción muy larga máximo 255 caracteres';
+          this.errors = 'Descripción muy larga, máximo 255 caracteres';
         });
-    },
-    edit() {
-      if (this.user.id === this.githubSession.user.id) {
-        this.editDescription = true;
-      }
-    },
-    cancel() {
-      this.form.description = this.user.description;
-      this.editDescription = false;
-      this.error = false;
     },
   },
   data() {
     const init = {
       user: this.githubUser,
-      editDescription: false,
       form: {
         description: '',
       },
-      readMoreActivated: true,
       errors: '',
-      maxLength: 160,
       error: false,
     };
     if (this.githubUser.description) {
-      if (this.githubUser.description.length > init.maxLength) {
-        init.readMoreActivated = false;
-      }
       init.form.description = init.user.description;
     }
 

--- a/app/javascript/components/profile/configuration.vue
+++ b/app/javascript/components/profile/configuration.vue
@@ -1,8 +1,15 @@
 <template>
   <div>
-    <p class="text-md font-semibold mb-6">
-      Configuración para recomendaciones
-    </p>
+    <div class="flex flex-row justify-between mb-6">
+      <p class="text-md font-semibold">
+        Configuración para recomendaciones
+      </p>
+      <default-preferences
+        :user="githubUser"
+        :variant="'green'"
+        :recommendation="false"
+      />
+    </div>
     <div class="grid grid-cols-12 gap-4">
       <div class="col-span-6">
         <label class="text-xs">{{ $i18n.t('message.recommendations.team') }}</label>
@@ -17,6 +24,7 @@
           <dropdown-timespan
             :timespans="timespans"
             :login="githubUser.login"
+            :variant="'profile'"
             class="flex-grow rounded"
           />
         </div>
@@ -27,20 +35,18 @@
 
 <script>
 
+import DefaultPreferences from '../recommendations/default-preferences.vue';
 import DropdownTeams from '../recommendations/dropdown-teams.vue';
 import DropdownTimespan from '../recommendations/dropdown-timespan.vue';
 
 export default {
   components: {
+    DefaultPreferences,
     DropdownTeams,
     DropdownTimespan,
   },
   props: {
     githubUser: {
-      type: Object,
-      required: true,
-    },
-    githubSession: {
       type: Object,
       required: true,
     },

--- a/app/javascript/components/profile/configuration.vue
+++ b/app/javascript/components/profile/configuration.vue
@@ -1,0 +1,57 @@
+<template>
+  <div>
+    <p class="text-md font-semibold mb-6">
+      Configuración para recomendaciones
+    </p>
+    <div class="grid grid-cols-12 gap-4">
+      <div class="col-span-6">
+        <label class="text-xs">{{ $i18n.t('message.recommendations.team') }}</label>
+        <dropdown-teams
+          :teams="teams"
+          :login="githubUser.login"
+        />
+      </div>
+      <div class="col-span-6">
+        <label class="text-xs">{{ $i18n.t('message.recommendations.time') }}</label>
+        <div class="flex pt-1">
+          <dropdown-timespan
+            :timespans="timespans"
+            :login="githubUser.login"
+            class="flex-grow rounded"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+import DropdownTeams from '../recommendations/dropdown-teams.vue';
+import DropdownTimespan from '../recommendations/dropdown-timespan.vue';
+
+export default {
+  components: {
+    DropdownTeams,
+    DropdownTimespan,
+  },
+  props: {
+    githubUser: {
+      type: Object,
+      required: true,
+    },
+    githubSession: {
+      type: Object,
+      required: true,
+    },
+    teams: {
+      type: Array,
+      default: () => {},
+    },
+    timespans: {
+      type: Array,
+      required: true,
+    },
+  },
+};
+</script>

--- a/app/javascript/components/profile/info.vue
+++ b/app/javascript/components/profile/info.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <div class="flex flex-row justify-between">
+      <p class="text-lg font-semibold mb-6">
+        Mis datos
+      </p>
+    </div>
+    <p class="text-sm font-semibold mb-1">
+      Acerca de mí
+    </p>
+    <p class="mb-4">
+      {{ githubUser.description }}
+    </p>
+    <p class="text-sm font-semibold mb-1">
+      Mis tags
+    </p>
+    <div class="flex flex-row items-center">
+      <div
+        v-for="tag in userTags"
+        :key="tag.id"
+        class="px-3 py-2 bg-red-500 rounded-full text-white mr-2"
+      >
+        {{ tag.name }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    githubUser: {
+      type: Object,
+      required: true,
+    },
+    githubSession: {
+      type: Object,
+      required: true,
+    },
+    userTags: {
+      type: Array,
+      required: true,
+    },
+  },
+};
+</script>

--- a/app/javascript/components/profile/info.vue
+++ b/app/javascript/components/profile/info.vue
@@ -1,26 +1,32 @@
 <template>
   <div>
-    <div class="flex flex-row justify-between">
-      <p class="text-lg font-semibold mb-6">
-        Mis datos
-      </p>
-    </div>
-    <p class="text-sm font-semibold mb-1">
-      Acerca de mí
-    </p>
-    <p class="mb-4">
-      {{ githubUser.description }}
-    </p>
-    <p class="text-sm font-semibold mb-1">
-      Mis tags
-    </p>
-    <div class="flex flex-row items-center">
-      <div
-        v-for="tag in userTags"
-        :key="tag.id"
-        class="px-3 py-2 bg-red-500 rounded-full text-white mr-2"
-      >
-        {{ tag.name }}
+    <div>
+      <div class="flex flex-row justify-between">
+        <p class="text-lg font-semibold mb-6">
+          Mis datos
+        </p>
+        <froggo-button
+          v-if="$parent.canEdit"
+          class="inline-flex items-center px-2"
+          variant="blue"
+          :icon-file-name="editIcon"
+          :only-icon="true"
+          @click="toggleEdit"
+        />
+      </div>
+      <div class="mb-4">
+        <profile-description
+          :github-user="githubUser"
+          :github-session="githubSession"
+        />
+      </div>
+      <div>
+        <user-tags
+          :github-user="githubUser"
+          :github-session="githubSession"
+          :tags="tags"
+          :user-tags="userTags"
+        />
       </div>
     </div>
   </div>
@@ -28,7 +34,17 @@
 
 <script>
 
+import FroggoButton from '../shared/froggo-button.vue';
+import ProfileDescription from '../profile-description.vue';
+import UsersApi from '../../api/users';
+import UserTags from './user-tags.vue';
+
 export default {
+  components: {
+    FroggoButton,
+    ProfileDescription,
+    UserTags,
+  },
   props: {
     githubUser: {
       type: Object,
@@ -38,10 +54,71 @@ export default {
       type: Object,
       required: true,
     },
+    tags: {
+      type: Array,
+      required: true,
+    },
     userTags: {
       type: Array,
       required: true,
     },
+  },
+  computed: {
+    editIcon() {
+      return this.isEditing ? 'close-icon.svg' : 'edit-icon.svg';
+    },
+  },
+  methods: {
+    toggleEdit() {
+      this.isEditing = !this.isEditing;
+    },
+    toggleModal() {
+      this.showModal = !this.showModal;
+      this.selectedTags = [];
+    },
+    onItemClicked(event) {
+      if (!this.myTags.map(this.getId).includes(event.item.id) &&
+          !this.selectedTags.map(this.getId).includes(event.item.id)) {
+        this.selectedTags.push(event.item);
+      }
+    },
+    getId(element) {
+      return element.id;
+    },
+    editTags(ids) {
+      UsersApi.updateUser(this.githubSession.user.id, {
+        tagIds: [... ids],
+      })
+        .then((res) => {
+          this.myTags = res.data.data.attributes.tags;
+        }).catch(() => {
+          this.error = true;
+        });
+    },
+    addTags() {
+      const ids = new Set([...this.myTags.map(this.getId), ... this.selectedTags.map(this.getId)]);
+      this.editTags(ids);
+      this.toggleModal();
+    },
+    eliminateTag(itemId) {
+      let ids = this.myTags.map(this.getId);
+      ids = ids.filter((item) => item !== itemId);
+      this.editTags(ids);
+    },
+    cancelTag(itemId) {
+      this.selectedTags = this.selectedTags.filter((item) => item.id !== itemId);
+    },
+  },
+  data() {
+    return {
+      isEditing: false,
+      dropdownTitle: 'Seleccionar tags',
+      noTagsMessage: 'No existen tags',
+      showModal: false,
+      selectedTags: [],
+      myTags: this.userTags,
+      error: false,
+    };
   },
 };
 </script>

--- a/app/javascript/components/profile/information.vue
+++ b/app/javascript/components/profile/information.vue
@@ -87,7 +87,7 @@ export default {
     },
     editTags(ids) {
       UsersApi.updateUser(this.githubSession.user.id, {
-        tagIds: [... ids],
+        tagIds: [...ids],
       })
         .then((res) => {
           this.myTags = res.data.data.attributes.tags;

--- a/app/javascript/components/profile/teams.vue
+++ b/app/javascript/components/profile/teams.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <p class="text-md font-semibold mb-5">
+      Mis equipos
+    </p>
+    <ul
+      v-for="team in teams"
+      :key="team.id"
+      class="list-disc list-inside"
+    >
+      <li class="text-md mb-5">
+        {{ team.name }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    githubUser: {
+      type: Object,
+      required: true,
+    },
+    githubSession: {
+      type: Object,
+      required: true,
+    },
+    teams: {
+      type: Array,
+      default: () => {},
+    },
+  },
+};
+</script>

--- a/app/javascript/components/profile/teams.vue
+++ b/app/javascript/components/profile/teams.vue
@@ -3,15 +3,17 @@
     <p class="text-md font-semibold mb-5">
       Mis equipos
     </p>
-    <ul
-      v-for="team in teams"
-      :key="team.id"
-      class="list-disc list-inside"
-    >
-      <li class="text-md mb-5">
-        {{ team.name }}
-      </li>
-    </ul>
+    <div class="grid grid-flow-row grid-cols-2 gap-x-4 gap-y-2 p-1">
+      <ul
+        v-for="team in teams"
+        :key="team.id"
+        class="list-disc list-inside"
+      >
+        <li class="text-md mb-5">
+          {{ team.name }}
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 

--- a/app/javascript/components/recommendations/default-preferences.vue
+++ b/app/javascript/components/recommendations/default-preferences.vue
@@ -1,37 +1,42 @@
 <template>
-  <button
+  <froggo-button
     v-if="!noTeamsInOrganization"
-    :class="`rounded-r-lg border-r border-t border-b p-3`"
     @click="setDefault"
+    :variant="this.variant"
+    :recommendation="this.recommendation"
   >
     <div
       v-if="success"
-      class="text-green-500"
     >
       OK!
     </div>
     <div
       v-else
-      class="text-black"
     >
       {{ $i18n.t('message.recommendations.setDefaultPreferences') }}
     </div>
-  </button>
+  </froggo-button>
 </template>
 <script>
 
 import { mapState } from 'vuex';
 
+import FroggoButton from '../shared/froggo-button.vue';
 import preferencesApi from '../../api/preferences';
 
 const TIMEOUT_IN_MS = 2000;
 
 export default {
+  component: {
+    FroggoButton,
+  },
   props: {
     user: {
       type: Object,
       required: true,
     },
+    variant: { type: String, default: 'black' },
+    recommendation: { type: Boolean, default: true },
   },
   data() {
     return {

--- a/app/javascript/components/recommendations/dropdown-teams.vue
+++ b/app/javascript/components/recommendations/dropdown-teams.vue
@@ -63,7 +63,7 @@ export default {
     selectedOrganizationTeams() {
       if (!this.selectedOrganization) return [];
 
-      return this.teams.filter(team => team.organization_id === this.selectedOrganization.id);
+      return this.teams.filter(team => team.organizationId === this.selectedOrganization.id);
     },
   },
   methods: {

--- a/app/javascript/components/recommendations/dropdown-timespan.vue
+++ b/app/javascript/components/recommendations/dropdown-timespan.vue
@@ -1,7 +1,10 @@
 <template>
   <froggo-dropdown>
     <template #btn>
-      <div class="flex items-center justify-between p-3 py-4 border rounded-l-lg">
+      <div
+        class="flex items-center justify-between p-3 py-4"
+        :class="[outlineClasses]"
+      >
         <div v-if="fetchingDefaultPreferences">
           {{ $i18n.t('message.recommendations.loading') }}
         </div>
@@ -47,6 +50,7 @@ export default {
       type: String,
       required: true,
     },
+    variant: { type: String, default: 'recommendations' },
   },
   computed: {
     ...mapState({
@@ -55,6 +59,14 @@ export default {
     }),
     selectedTimespan() {
       return this.timespans.find(timespan => timespan.key === this.selectedTimespanKey);
+    },
+    outlineClasses() {
+      const classes = {
+        recommendations: 'border rounded-l-lg',
+        profile: 'border rounded-lg',
+      };
+
+      return classes[this.variant];
     },
   },
   methods: {

--- a/app/javascript/components/shared/froggo-button.vue
+++ b/app/javascript/components/shared/froggo-button.vue
@@ -43,9 +43,9 @@ export default {
     colorClasses() {
       const classes = {
         black: 'text-black',
-        blue: 'text-froggoBlue border-froggoBlue hover:bg-gray-100 text-md',
+        blue: 'text-froggoBlue-500 border-froggoBlue-500 hover:bg-gray-100 text-md',
         red: 'text-red-600 border-red-600 hover:bg-gray-100 text-md',
-        green: 'text-froggoGreen border-froggoGreen hover:bg-gray-100 text-md',
+        green: 'text-froggoGreen-500 border-froggoGreen-500 hover:bg-gray-100 text-md',
         disabled: 'text-gray-300 border-gray-300 cursor-default text-md',
       };
       const variant = this.disabled ? 'disabled' : this.variant;

--- a/app/javascript/components/shared/froggo-button.vue
+++ b/app/javascript/components/shared/froggo-button.vue
@@ -1,0 +1,69 @@
+<template>
+  <component
+    :is="tag"
+    class="flex items-center leading-none transition-colors duration-150 ease-in-out shadow focus:outline-none"
+    :class="[colorClasses, shapeClasses, textClasses]"
+    :disabled="disabled"
+    v-on="$listeners"
+    v-bind="$attrs"
+  >
+    <inline-svg
+      v-if="iconFileName"
+      :src="require(`../../../assets/images/icons/${iconFileName}`).default"
+      class="flex-grow-0 fill-current"
+    />
+    <div
+      v-if="!onlyIcon"
+      class="flex-1 text-center"
+    >
+      <slot />
+    </div>
+    <inline-svg
+      v-if="rightIconFileName"
+      :src="require(`../../../assets/images/icons/${rightIconFileName}`).default"
+      class="flex-grow-0 fill-current"
+    />
+  </component>
+</template>
+
+<script>
+
+export default {
+  props: {
+    tag: { type: String, default: 'button' },
+    variant: { type: String, default: 'blue' },
+    recommendation: { type: Boolean, default: false },
+    iconFileName: { type: String, default: null },
+    small: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+    rightIconFileName: { type: String, default: null },
+    onlyIcon: { type: Boolean, default: false },
+  },
+  computed: {
+    colorClasses() {
+      const classes = {
+        black: 'text-black',
+        blue: 'text-froggoBlue border-froggoBlue hover:bg-gray-100 text-md',
+        red: 'text-red-600 border-red-600 hover:bg-gray-100 text-md',
+        green: 'text-froggoGreen border-froggoGreen hover:bg-gray-100 text-md',
+        disabled: 'text-gray-300 border-gray-300 cursor-default text-md',
+      };
+      const variant = this.disabled ? 'disabled' : this.variant;
+
+      return classes[variant];
+    },
+    textClasses() {
+      const classesWithText = this.recommendation ? 'p-3 text-base' : 'h-8 px-10 text-md';
+      const classesWithoutText = 'h-8 w-8 p-2 text-md';
+
+      return this.onlyIcon ? classesWithoutText : classesWithText;
+    },
+    shapeClasses() {
+      const primaryStyle = 'rounded-lg border';
+      const recommendationStyle = 'rounded-r-lg border-r border-t border-b';
+
+      return this.recommendation ? recommendationStyle : primaryStyle;
+    },
+  },
+};
+</script>

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -136,7 +136,7 @@ export default {
       loading: 'Cargando...',
       time: 'Tiempo',
       team: 'Equipo',
-      setDefaultPreferences: 'predeterminar',
+      setDefaultPreferences: 'Predeterminar',
       noTeamsInOrganization: 'Aún no perteneces a un equipo en esta organización',
       noOrganizations: 'Aún no perteneces a ninguna organización',
       noTeams: 'Sin equipos',

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,6 +24,7 @@ import FroggoDropdown from '../components/froggo-dropdown.vue';
 import Dropdown from '../components/pl-dropdown.vue';
 import TeamsDropdown from '../components/teams-dropdown.vue';
 import OrganizationsDropdown from '../components/organizations-dropdown.vue';
+import FroggoButton from '../components/shared/froggo-button.vue';
 import FroggoTeamEdit from '../components/froggo-team-edit.vue';
 import FroggoTeamForm from '../components/froggo-team-form.vue';
 import FroggoTeamShow from '../components/froggo-team-show.vue';
@@ -43,7 +44,7 @@ import FroggoTeamMetrics from '../components/froggo-team-metrics.vue';
 import PercentageDropdown from '../components/percentage-dropdown.vue';
 import ProfileDescription from '../components/profile-description.vue';
 import TagsShow from '../components/tags-show';
-import UserTags from '../components/user-tags.vue';
+import UserTags from '../components/profile/user-tags.vue';
 import TeamTagsContainer from '../components/profile/team-tags-container.vue';
 
 import Locales from '../locales/locales.js';
@@ -74,6 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
   Vue.component('dropdown', Dropdown);
   Vue.component('teams-dropdown', TeamsDropdown);
   Vue.component('organizations-dropdown', OrganizationsDropdown);
+  Vue.component('froggo-button', FroggoButton);
   Vue.component('froggo-dropdown', FroggoDropdown);
   Vue.component('froggo-team-edit', FroggoTeamEdit);
   Vue.component('froggo-team-form', FroggoTeamForm);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -38,6 +38,7 @@ import ProfileRecommendations from '../components/profile/recommendations.vue';
 import PrFeed from '../components/pr-feed.vue';
 import PrShow from '../components/pr-show.vue';
 import ProfileMetrics from '../components/profile/metrics.vue';
+import ProfileCard from '../components/profile-card.vue';
 import FroggoTeamMetrics from '../components/froggo-team-metrics.vue';
 import PercentageDropdown from '../components/percentage-dropdown.vue';
 import ProfileDescription from '../components/profile-description.vue';
@@ -87,6 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
   Vue.component('pr-feed', PrFeed);
   Vue.component('pr-show', PrShow);
   Vue.component('profile-metrics', ProfileMetrics);
+  Vue.component('profile-card', ProfileCard);
   Vue.component('froggo-team-metrics', FroggoTeamMetrics);
   Vue.component('percentage-dropdown', PercentageDropdown);
   Vue.component('profile-description', ProfileDescription);

--- a/app/views/github_users/_profile_card.html.erb
+++ b/app/views/github_users/_profile_card.html.erb
@@ -1,60 +1,10 @@
 <div class="card profile">
-  <div class="profile__section">
-    <div class="profile-header">
-      <div>
-        <div class="profile-info">
-          <%= image_tag @github_user.avatar_url, class: 'profile-info__picture' %>
-          <div class="profile-info__info">
-            <div class="profile-info__name">
-              <%= @github_user.name || t('messages.profile.no_name') %>
-            </div>
-            <%= link_to @github_user.html_url, class: 'profile-info__username' do %>
-              <%= octicon "octoface" %>
-              <span>@<%= @github_user.login %></span>
-            <% end %>
-          </div>
-        </div>
-        <div>
-          <user-tags
-            :github-user="<%= @github_user.to_json%>"
-            :github-session="<%= @github_session.to_json%>"
-            :tags="<%= @tags.to_json%>"
-            :user-tags="<%=@user_tags.to_json%>"
-          />
-        </div>
-        <profile-description
-          :github-user="<%= @github_user.to_json%>"
-          :github-session="<%= @github_session.to_json%>"
-        />
-      </div>
-      <div class="profile-teams">
-        <div class="profile-teams__hint">
-          <%= t('messages.profile.teams_dropdown_hint') %>
-        </div>
-        <profile-dropdowns
-          github-login="<%= @github_user.login %>"
-          :organizations="<%= @organizations.to_json %>"
-          :teams="<%= @teams.to_json %>"
-          :months-options="<%= timespans_with_name.to_json %>"
-        />
-      </div>
-    </div>
-  <div class="profile-prs">
-    <% @open_prs.each do |pr| %>
-        <open-pr
-          :pr="<%= pr[:pull_request].to_json %> | camelizeKeys"
-          :reviewers="<%= pr[:reviewers].to_json %> | camelizeKeys"
-        >
-        </open-pr>
-    <% end %>
-  </div>
-  <div class="profile__section">
-    <profile-recommendations />
-  </div>
-  <div class="profile__section">
-    <team-tags-container :tags="<%= @tags.to_json%>" />
-  </div>
-  <div class="profile__section">
-    <profile-metrics />
-  </div>
+  <profile-card
+    :github-user="<%= @github_user.to_json%> | camelizeKeys"
+    :github-session="<%= @github_session.to_json%> | camelizeKeys"
+    :teams="<%= @teams.to_json %> | camelizeKeys"
+    :timespans="<%= timespans_options_with_name.to_json %> | camelizeKeys"
+    :tags="<%= @tags.to_json%>"
+    :user-tags="<%=@user_tags.to_json%>"
+  />
 </div>

--- a/app/views/github_users/_profile_card.html.erb
+++ b/app/views/github_users/_profile_card.html.erb
@@ -1,4 +1,4 @@
-<div class="card profile">
+<div class="mt-12 mr-12">
   <profile-card
     :github-user="<%= @github_user.to_json%> | camelizeKeys"
     :github-session="<%= @github_session.to_json%> | camelizeKeys"

--- a/app/views/github_users/show.html.erb
+++ b/app/views/github_users/show.html.erb
@@ -1,3 +1,1 @@
-<div>
-  <%= render 'profile_card' %>
-</div>
+<%= render 'profile_card' %>

--- a/app/views/github_users/show.html.erb
+++ b/app/views/github_users/show.html.erb
@@ -1,3 +1,3 @@
-<div class="container w-3/4 mx-auto">
+<div>
   <%= render 'profile_card' %>
 </div>

--- a/app/views/recommendations/show.html.erb
+++ b/app/views/recommendations/show.html.erb
@@ -1,5 +1,5 @@
 <recommendations
- :teams="<%= @teams.to_json %>"
+ :teams="<%= @teams.to_json %> | camelizeKeys"
  :timespans="<%= timespans_options_with_name.to_json %>"
  :user="<%= GithubUserSerializer.new(@github_session.user).to_json %>"
  :pull-requests="<%= @open_prs %> | camelizeKeys"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,11 @@ module.exports = {
       },
       colors: {
         primary: '#2fcab5',
+        froggoGreen: '#27A594',
+        froggoBlue: {
+          default: '#38405F',
+          dark: '#232943',
+        },
       },
     },
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,10 +17,12 @@ module.exports = {
       },
       colors: {
         primary: '#2fcab5',
-        froggoGreen: '#27A594',
+        froggoGreen: {
+          500: '#27A594',
+        },
         froggoBlue: {
-          default: '#38405F',
-          dark: '#232943',
+          500: '#38405F',
+          700: '#232943',
         },
       },
     },


### PR DESCRIPTION
## Contexto
Creemos que Froggo requiere de un aire nuevo para que se entienda mejor y funcione como esperamos.

Actualmente la vista de perfil de Froggo todo agrupado: información personal, tags, preferencias, recomendaciones, métricas, etc. Además está todo en un .erb, por lo que la idea es moverlo a Vue con Tailwind.

Se armó un diseño en [Figma](https://www.figma.com/file/ZZvsjJJIkiHhX8NRVxRuXV/Froggo?node-id=508%3A2), donde en el perfil se muestran solo los datos personales, los equipos y la configuración de las recomendaciones.

## Qué se está haciendo
- Se crea una nueva vista independiente para el Perfil de Froggo como componente de Vue, en `profile_card.vue`. Contiene secciones para cada tipo de información y cada sección llama a su propio componente.
  - Se agregó el componente `info.vue`, donde se agrupa la información del usuario, como el nombre, el username, la foto, la descripción y los tags
     - Se adaptó la vista de tags del usuario en `user-tags.vue`. Se usa el nuevo diseño, pero se mantiene el modal de edición de tags anterior.
     - Se adaptó la descripción del usuario existente en `profile-description.vue` para que quede como en el diseño de Figma.
  - Se agregó el componente `configuration.vue`, que contiene la sección de configuración de las recomendaciones. Gran parte de sus elementos son reciclados de la vista de recomendaciones de Froggo.
  - Se agregó una sección con los equipos del usuario y su respectivo componente; `teams.vue`. Queda pendiente la edición de equipos en la vista del perfil.
- Se creó un botón genérico con el estilo del nuevo diseño de Figma, para poder reutilizarlo en otras partes de Froggo.

### En particular hay que revisar
- Que el diseño esté bueno.
- Los componentes de descripción y tags, que son los que tienen más interacción con el backend.
​
### Info Adicional (pantallazos, links, fuentes, etc.)

Vista del perfil antigua:
![Screen Shot 2021-11-16 at 11 26 21](https://user-images.githubusercontent.com/42162243/142003525-8b170b7a-7f08-49be-a707-e7d6ffd582ed.png)

Diseño en Figma:
![Screen Shot 2021-11-16 at 11 27 48](https://user-images.githubusercontent.com/42162243/142003647-1f009fde-daa2-4e6e-9b70-f3f2f2fead76.png)

Vista de perfil nueva:
![Screen Shot 2021-11-16 at 11 24 49](https://user-images.githubusercontent.com/42162243/142003684-2b6a9269-91be-4567-93ea-974b82efafff.png)

Vista de perfil nueva, editando:
![Screen Shot 2021-11-16 at 11 29 34](https://user-images.githubusercontent.com/42162243/142004078-5bd82bb6-3d47-474b-a0c9-7774be27b47b.png)


