### PR TITLE
Feat/profile edit teams

### DIFF
--- a/app/controllers/api/v1/froggo_team_memberships_controller.rb
+++ b/app/controllers/api/v1/froggo_team_memberships_controller.rb
@@ -1,0 +1,28 @@
+class Api::V1::FroggoTeamMembershipsController < Api::V1::BaseController
+  before_action :authenticate_github_user
+
+  def index
+    github_user = GithubUser.find(params[:github_user_id])
+    respond_with github_user.froggo_team_memberships
+  end
+
+  def update
+    authorize froggo_team_membership
+    froggo_team_membership.update! update_params
+    respond_with froggo_team_membership
+  end
+
+  private
+
+  def froggo_team_membership
+    @froggo_team_membership ||= FroggoTeamMembership.find(params[:id])
+  end
+
+  def update_params
+    params.permit(:is_member_active)
+  end
+
+  def pundit_user
+    github_session.user
+  end
+end

--- a/app/javascript/api/froggo_team_memberships.js
+++ b/app/javascript/api/froggo_team_memberships.js
@@ -1,0 +1,17 @@
+import api from './index';
+
+export default {
+  updateFroggoTeamMembership(froggoTeamMembershipId, body) {
+    return api({
+      method: 'patch',
+      url: `/api/v1/froggo_team_memberships/${froggoTeamMembershipId}`,
+      data: body,
+    });
+  },
+  getFroggoTeamMemberships(githubUserId) {
+    return api({
+      method: 'get',
+      url: `/api/v1/github_users/${githubUserId}/froggo_team_memberships`,
+    });
+  },
+};

--- a/app/javascript/components/profile-card.vue
+++ b/app/javascript/components/profile-card.vue
@@ -39,6 +39,7 @@
           :github-user="githubUser"
           :github-session="githubSession"
           :teams="teams"
+          can-edit
         />
       </div>
       <div

--- a/app/policies/froggo_team_membership_policy.rb
+++ b/app/policies/froggo_team_membership_policy.rb
@@ -1,0 +1,15 @@
+class FroggoTeamMembershipPolicy < ApplicationPolicy
+  def update?
+    organization_matches?
+  end
+
+  private
+
+  def organization_matches?
+    user.organizations.include?(froggo_team_membership_organization)
+  end
+
+  def froggo_team_membership_organization
+    FroggoTeam.find(record.froggo_team_id).organization
+  end
+end

--- a/app/serializers/api/v1/froggo_team_membership_serializer.rb
+++ b/app/serializers/api/v1/froggo_team_membership_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::FroggoTeamMembershipSerializer < ActiveModel::Serializer
+  attributes :id, :github_user_id, :froggo_team_id, :is_member_active
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         resources :likes, only: [:create, :destroy]
       end
       resources :github_users, only: [] do
+        resources :froggo_team_memberships, only: [:index]
         get '/open_prs' => :open_prs, on: :collection
         get '/current' => :logged_user, on: :collection
       end
@@ -27,6 +28,8 @@ Rails.application.routes.draw do
       post 'pull_request_reviewer/add' => 'pull_request_reviewers#add_reviewer'
       get 'github_users/:id/preferences' => 'preferences#show'
       patch 'github_users/:id/preferences' => 'preferences#update'
+
+      resources :froggo_team_memberships, only: [:update], controller: 'froggo_team_memberships'
     end
   end
   mount Rswag::Api::Engine => '/api-docs'

--- a/spec/controllers/api/v1/froggo_team_memberships_controller_spec.rb
+++ b/spec/controllers/api/v1/froggo_team_memberships_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::FroggoTeamMembershipsController, type: :controller do
+  let(:user) { create(:github_user, login: "platanus_user") }
+  let(:organization) { create(:organization, login: "platanus", members: [user]) }
+  let(:team) { create(:froggo_team, name: "platanus_team", organization: organization) }
+  let(:membership) do
+    create(:froggo_team_membership, github_user: user, froggo_team: team)
+  end
+  let(:github_session) { instance_double("GithubSession") }
+
+  before do
+    allow(github_session).to receive(:token).and_return("token")
+    allow(github_session).to receive(:organizations).and_return(
+      [{ id: organization.gh_id, role: "member" }]
+    )
+    allow(github_session).to receive(:user).and_return(user)
+    allow(controller).to receive(:authenticate_github_user).and_return(true)
+    allow(GithubSession).to receive(:new).and_return(github_session)
+  end
+
+  describe '#index' do
+    it 'responds with ok' do
+      get :index, params: { github_user_id: user.id }, format: :json
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe '#update' do
+    context 'when user is from other organization' do
+      before do
+        allow(controller).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
+        patch :update, params: { id: membership.id, is_member_active: false }, format: :json
+      end
+
+      it { expect(response).to have_http_status(:unauthorized) }
+    end
+
+    context 'when user is from the same organization' do
+      before do
+        allow(controller).to receive(:authorize)
+        patch :update, params: { id: membership.id, is_member_active: false }, format: :json
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+    end
+  end
+end


### PR DESCRIPTION
### **Contexto**
Se está rediseñando la vista del perfil de Froggo. Entre las nuevas funcionalidades está mostrar los equipos del usuario. Actualmente solo se muestran los equipos, pero se busca incluir la posibilidad de activar y desactivar al usuario en los distintos grupos.

El modelo FroggoTeamMemberships contiene la relación entre los usuarios y los equipos, estableciendo la pertenencia a cada equipo y si el usuario está activo en el equipo o no.

### **Qué se está haciendo**
- Se crea un controlador en la api para `FroggoTeamMemberships`, para obtener todos los equipos a los que pertenece el usuario y actualizar el estado del usuario (activo/inactivo) en un equipo.
  - Se agregan los tests y policies correspondientes
- Se actualiza la vista de equipos para incluir los toggles de activación de los equipos.

### **En particular hay que revisar**

Los cambios en la vista de equipos (`team.vue`) que fueron la parte más complicada.

---

### **Info Adicional (pantallazos, links, fuentes, etc.)**

Video del funcionamiento:
https://user-images.githubusercontent.com/42162243/142485471-3c898487-1d27-40f7-9002-2b7dee53c5fa.mov

Antes: 
![Screen Shot 2021-11-16 at 11 24 49](https://user-images.githubusercontent.com/42162243/142488413-9ca853e2-fea4-45d7-9d40-c81236a8b219.png)

Ahora:
![Screen Shot 2021-11-18 at 16 31 50](https://user-images.githubusercontent.com/42162243/142488449-5a809685-4ab7-4724-b993-569eb3586a57.png)
 