### PR TITLE
Feat/profile edit multiple teams

### DIFF
--- a/app/controllers/api/v1/froggo_team_memberships_controller.rb
+++ b/app/controllers/api/v1/froggo_team_memberships_controller.rb
@@ -2,7 +2,6 @@ class Api::V1::FroggoTeamMembershipsController < Api::V1::BaseController
   before_action :authenticate_github_user
 
   def index
-    github_user = GithubUser.find(params[:github_user_id])
     respond_with github_user.froggo_team_memberships
   end
 
@@ -12,10 +11,21 @@ class Api::V1::FroggoTeamMembershipsController < Api::V1::BaseController
     respond_with froggo_team_membership
   end
 
+  def update_all
+    ActiveRecord::Base.transaction do
+      github_user.froggo_team_memberships.each { |x| x.update!(update_params) }
+    end
+    respond_with github_user.froggo_team_memberships
+  end
+
   private
 
   def froggo_team_membership
     @froggo_team_membership ||= FroggoTeamMembership.find(params[:id])
+  end
+
+  def github_user
+    @github_user ||= GithubUser.find(params[:github_user_id])
   end
 
   def update_params

--- a/app/javascript/api/froggo_team_memberships.js
+++ b/app/javascript/api/froggo_team_memberships.js
@@ -1,6 +1,12 @@
 import api from './index';
 
 export default {
+  getFroggoTeamMemberships(githubUserId) {
+    return api({
+      method: 'get',
+      url: `/api/v1/github_users/${githubUserId}/froggo_team_memberships`,
+    });
+  },
   updateFroggoTeamMembership(froggoTeamMembershipId, body) {
     return api({
       method: 'patch',
@@ -8,10 +14,11 @@ export default {
       data: body,
     });
   },
-  getFroggoTeamMemberships(githubUserId) {
+  updateAllFroggoTeamMemberships(githubUserId, body) {
     return api({
-      method: 'get',
+      method: 'patch',
       url: `/api/v1/github_users/${githubUserId}/froggo_team_memberships`,
+      data: body,
     });
   },
 };

--- a/app/javascript/components/profile/information.vue
+++ b/app/javascript/components/profile/information.vue
@@ -36,7 +36,6 @@
 
 import FroggoButton from '../shared/froggo-button.vue';
 import ProfileDescription from '../profile-description.vue';
-import UsersApi from '../../api/users';
 import UserTags from './user-tags.vue';
 
 export default {
@@ -72,52 +71,10 @@ export default {
     toggleEdit() {
       this.isEditing = !this.isEditing;
     },
-    toggleModal() {
-      this.showModal = !this.showModal;
-      this.selectedTags = [];
-    },
-    onItemClicked(event) {
-      if (!this.myTags.map(this.getId).includes(event.item.id) &&
-          !this.selectedTags.map(this.getId).includes(event.item.id)) {
-        this.selectedTags.push(event.item);
-      }
-    },
-    getId(element) {
-      return element.id;
-    },
-    editTags(ids) {
-      UsersApi.updateUser(this.githubSession.user.id, {
-        tagIds: [...ids],
-      })
-        .then((res) => {
-          this.myTags = res.data.data.attributes.tags;
-        }).catch(() => {
-          this.error = true;
-        });
-    },
-    addTags() {
-      const ids = new Set([...this.myTags.map(this.getId), ... this.selectedTags.map(this.getId)]);
-      this.editTags(ids);
-      this.toggleModal();
-    },
-    eliminateTag(itemId) {
-      let ids = this.myTags.map(this.getId);
-      ids = ids.filter((item) => item !== itemId);
-      this.editTags(ids);
-    },
-    cancelTag(itemId) {
-      this.selectedTags = this.selectedTags.filter((item) => item.id !== itemId);
-    },
   },
   data() {
     return {
       isEditing: false,
-      dropdownTitle: 'Seleccionar tags',
-      noTagsMessage: 'No existen tags',
-      showModal: false,
-      selectedTags: [],
-      myTags: this.userTags,
-      error: false,
     };
   },
 };

--- a/app/javascript/components/shared/froggo-button.vue
+++ b/app/javascript/components/shared/froggo-button.vue
@@ -44,9 +44,9 @@ export default {
       const classes = {
         black: 'text-black',
         blue: 'text-froggoBlue-500 border-froggoBlue-500 hover:bg-gray-100 text-md',
-        red: 'text-red-600 border-red-600 hover:bg-gray-100 text-md',
+        red: 'text-red-500 border-red-500 hover:bg-gray-100 text-md',
         green: 'text-froggoGreen-500 border-froggoGreen-500 hover:bg-gray-100 text-md',
-        disabled: 'text-gray-300 border-gray-300 cursor-default text-md',
+        disabled: 'text-gray-500 border-gray-500 cursor-default text-md',
       };
       const variant = this.disabled ? 'disabled' : this.variant;
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
         resources :likes, only: [:create, :destroy]
       end
       resources :github_users, only: [] do
-        resources :froggo_team_memberships, only: [:index]
+        resources :froggo_team_memberships, only: [:index] do
+          patch '/' => :update_all, on: :collection
+        end
         get '/open_prs' => :open_prs, on: :collection
         get '/current' => :logged_user, on: :collection
       end
@@ -29,7 +31,7 @@ Rails.application.routes.draw do
       get 'github_users/:id/preferences' => 'preferences#show'
       patch 'github_users/:id/preferences' => 'preferences#update'
 
-      resources :froggo_team_memberships, only: [:update], controller: 'froggo_team_memberships'
+      resources :froggo_team_memberships, only: [:update]
     end
   end
   mount Rswag::Api::Engine => '/api-docs'

--- a/spec/controllers/api/v1/froggo_team_memberships_controller_spec.rb
+++ b/spec/controllers/api/v1/froggo_team_memberships_controller_spec.rb
@@ -45,4 +45,14 @@ RSpec.describe Api::V1::FroggoTeamMembershipsController, type: :controller do
       it { expect(response).to have_http_status(:ok) }
     end
   end
+
+  describe '#update_all' do
+    before do
+      patch :update_all, params: { github_user_id: user.id, is_member_active: false }, format: :json
+    end
+
+    it 'responds with ok' do
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end


### PR DESCRIPTION
### **Contexto**
Se está agregando una funcionalidad a la vista de perfil de Froggo, consistente en mostrar los equipos del usuario en su vista del perfil. Ya se había implementado un switch para activarse/desactivarse en cada equipo, y ahora se necesitaba agregar un botón "desactivarme en todos"

### **Qué se está haciendo**
- Se crea una nueva acción en el controlador de `FroggoTeamMemberships` llamada `update all`, que setea al usuario como inactivo en todos sus equipos.
  - Se agrega el test respectivo
- Se agrega el botón al componente de equipos del perfil.

### **En particular hay que revisar**

---

### **Info Adicional (pantallazos, links, fuentes, etc.)**

https://user-images.githubusercontent.com/42162243/142678281-72e1580b-b693-43cb-99b9-5a3d49b7cc8a.mov



