### PR TITLE
refactor(profile/desciption): change button behaviour when disabled

### DIFF
--- a/app/javascript/components/profile-description.vue
+++ b/app/javascript/components/profile-description.vue
@@ -3,23 +3,19 @@
     <div
       class="flex flex-row justify-between mb-1"
     >
-      <p class="text-sm font-semibold">
+      <p class="text-sm font-semibold mb-1">
         Acerca de mí
       </p>
       <div
         v-if="$parent.isEditing"
       >
         <froggo-button
-          v-if="descriptionChanged"
-          @click="submit"
           variant="green"
+          :disabled="buttonDisabled"
+          @click="submit"
         >
           Guardar
         </froggo-button>
-        <div
-          v-else
-          class="h-8"
-        />
       </div>
     </div>
     <div
@@ -37,7 +33,7 @@
         name="description"
         type="text"
         placeholder="Agrega una descripción de máximo 255 caracteres"
-        class="flex flex-grow resize-none border rounded w-full p-2"
+        class="flex flex-grow resize-none border border-gray-500 rounded w-full p-2"
         v-model="form.description"
       />
     </div>
@@ -65,8 +61,8 @@ export default {
     },
   },
   computed: {
-    descriptionChanged() {
-      return this.form.description !== this.user.description;
+    buttonDisabled() {
+      return this.form.description === this.user.description;
     },
   },
   methods: {


### PR DESCRIPTION
### Contexto
Se está haciendo un rediseño de la vista de perfil de usuario en Froggo. Uno de los cambios es en la descripción del usuario, la cual se puede editar, y para guardar los cambios se usa un botón guardar.

Antes el botón guardar desaparecía cuando no había cambios que guardar en la descripción.

### Qué se está haciendo
Ahora el botón no desaparece, solo se deshabilita cuando no hay cambios que guardar.

### En particular hay que revisar

---

### Info Adicional (pantallazos, links, fuentes, etc.)

Botón desactivado:
![Screen Shot 2021-11-22 at 09 40 01](https://user-images.githubusercontent.com/42162243/142863464-7b51fe2d-21d6-4ea5-9b0c-1702297ee824.png)

Botón activado:
![Screen Shot 2021-11-22 at 09 38 41](https://user-images.githubusercontent.com/42162243/142863335-878b138f-0a0b-4607-b480-1505e3ff2695.png)


