### PR TITLE
fix(github_user): fix show view of other users

### DIFF
--- a/app/controllers/github_users_controller.rb
+++ b/app/controllers/github_users_controller.rb
@@ -3,11 +3,10 @@ class GithubUsersController < ApplicationController
 
   def show
     @github_user = GithubUser.find(params[:id])
-    @teams = froggo_teams
+    @teams = github_user.froggo_teams
     @organizations = @github_user.organizations
     @user_tags = @github_user.tags
     @tags = Tag.all
-    @open_prs = open_prs(github_user)
   end
 
   # GET /me
@@ -15,28 +14,5 @@ class GithubUsersController < ApplicationController
     redirect_to user_path(github_user)
   rescue ActiveRecord::RecordNotFound
     redirect_to root_path
-  end
-
-  private
-
-  def github_teams(github_user)
-    github_session.fetch_teams_for_user(github_user)
-  end
-
-  def froggo_teams
-    github_session.user.get_froggo_teams.sort_by { |team| team[:name].downcase }
-  end
-
-  def user_teams(github_user)
-    gh_teams = github_teams(github_user)
-    gh_teams.each do |team|
-      team[:froggo_team] = false
-    end
-    gh_teams.concat(froggo_teams)
-            .sort_by { |team| team[:name].downcase }
-  end
-
-  def open_prs(github_user)
-    GithubPullRequestService.new(token: github_session.token).open_prs(github_user.login)
   end
 end

--- a/app/javascript/components/profile-card.vue
+++ b/app/javascript/components/profile-card.vue
@@ -7,7 +7,7 @@
       >
       <div class="flex flex-col items-center text-base">
         <p class="mb-4">
-          {{ githubUser.name || t('messages.profile.no_name') }}
+          {{ githubUser.name || $t('message.profile.noName') }}
         </p>
 
         <a
@@ -39,7 +39,7 @@
           :github-user="githubUser"
           :github-session="githubSession"
           :teams="teams"
-          can-edit
+          :can-edit="canEdit"
         />
       </div>
       <div

--- a/app/javascript/components/profile/teams.vue
+++ b/app/javascript/components/profile/teams.vue
@@ -5,6 +5,7 @@
         Mis equipos
       </p>
       <froggo-button
+        v-if="canEdit"
         :variant="'red'"
         :recommendation="false"
         :disabled="disabled"

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -14,6 +14,7 @@ export default {
       successfullyDefaulted: 'Atributos predeterminados exitosamente',
     },
     profile: {
+      noName: 'Sin nombre',
       noTeams: 'Sin equipos',
       teamsDropdownTitle: 'Equipos',
       noOrganizations: 'Sin organizaciones',


### PR DESCRIPTION
### Contexto
Se cambió el diseño de la vista de perfil de usuarios según [este Figma](https://www.figma.com/file/ZZvsjJJIkiHhX8NRVxRuXV/Froggo?node-id=508%3A2). Uno de los requerimientos era que los otros usuarios pudieran ver la vista de perfil de otros usuarios, pero no editarla.

### Qué se está haciendo
- Se arregla la obtención de los equipos del usuario en el controlador, lo que permite que ahora se pueda ver el perfil de otros usuarios. Además se elimina código no usado.
- Se arregla detalle de los mensajes en la vista del perfil

### En particular hay que revisar

---

### Info Adicional (pantallazos, links, fuentes, etc.)

Vista del propio usuario:
![Screen Shot 2021-11-22 at 10 54 10](https://user-images.githubusercontent.com/42162243/142873735-1208616c-9260-45f4-bc52-41d56cff41a0.png)

Vista de otro usuario:
![Screen Shot 2021-11-22 at 10 54 00](https://user-images.githubusercontent.com/42162243/142873755-6b1d6914-eecf-4c98-854f-c333a6580d60.png)

