### PR TITLE
feat(profile/teams): add activate all button

### DIFF
--- a/app/javascript/components/profile/teams.vue
+++ b/app/javascript/components/profile/teams.vue
@@ -6,12 +6,11 @@
       </p>
       <froggo-button
         v-if="canEdit"
-        :variant="'red'"
+        :variant="this.allDeactivated ? 'green' : 'red' "
         :recommendation="false"
-        :disabled="disabled"
         @click="updateAllFroggoTeamMemberships"
       >
-        Desactivar todos
+        {{ this.allDeactivated ? 'Activar todos' : 'Desactivar todos' }}
       </froggo-button>
     </div>
     <p
@@ -76,7 +75,7 @@ export default {
     listType() {
       return this.canEdit ? '' : 'list-disc';
     },
-    disabled() {
+    allDeactivated() {
       const state = [];
       for (const [, membership] of Object.entries(this.froggoTeamMemberships)) {
         state.push(membership.isMemberActive);
@@ -111,7 +110,7 @@ export default {
     },
     updateAllFroggoTeamMemberships() {
       const newMembershipStatus = {
-        isMemberActive: false,
+        isMemberActive: this.allDeactivated,
       };
       froggoTeamMembershipsApi.updateAllFroggoTeamMemberships(this.githubUser.id, newMembershipStatus)
         .then((response) => {


### PR DESCRIPTION
### Contexto
En Froggo se está renovando el diseño de la vista del perfil de usuario. Una nueva funcionalidad que se agregó es la de mostrar los equipos del usuario, junto con la posibilidad de que se active o desactive de esos equipos. Además, se incluyó un botón "desactivarme en todos", para facilitar la desactivación de un usuario de sus equipos.

El problema es que una vez que se desactivan todos los equipos, el usuario tiene que volver a activarlos uno a uno. Por eso, cuando todos los equipos estén desactivados, se necesita un botón para volver a activarlos todos.

### Qué se está haciendo
- Se cambia el botón para incluir la opción "activarme en todos" cuando los equipos estén desactivados

### En particular hay que revisar

---

### Info Adicional (pantallazos, links, fuentes, etc.)

Video funcionamiento:

https://user-images.githubusercontent.com/42162243/143584894-10d3923d-5cad-471b-9ca6-29e8610fd970.mov


