### PR TITLE
Send organization_id on PR api

### DIFF
--- a/app/controllers/api/v1/github_users_controller.rb
+++ b/app/controllers/api/v1/github_users_controller.rb
@@ -43,9 +43,10 @@ class Api::V1::GithubUsersController < Api::V1::BaseController
 
   def open_prs
     gh_user = github_session.user
+    open_prs = gh_pr_service.open_prs(gh_user.login)
     response = { response: {
       github_username: gh_user.login,
-      open_prs: gh_pr_service.open_prs(gh_user.login)
+      open_prs: serialized_open_prs(open_prs)
     } }
     respond_with response
   end
@@ -128,5 +129,14 @@ class Api::V1::GithubUsersController < Api::V1::BaseController
 
   def gh_pr_service
     @gh_pr_service ||= GithubPullRequestService.new(token: github_session.token)
+  end
+
+  def serialized_open_prs(open_prs)
+    open_prs.map do |x|
+      {
+        pull_request: Api::V1::PullRequestSerializer.new(x[:pull_request]).as_json,
+        reviewers: x[:reviewers].as_json
+      }
+    end
   end
 end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -70,6 +70,7 @@ class PullRequest < ApplicationRecord
   delegate :name, to: :repository, prefix: true, allow_nil: true
   delegate :name, to: :owner, prefix: true, allow_nil: true
   delegate :login, to: :owner, prefix: true, allow_nil: true
+  delegate :organization_id, to: :repository, allow_nil: true
 end
 
 # == Schema Information

--- a/app/serializers/api/v1/pull_request_serializer.rb
+++ b/app/serializers/api/v1/pull_request_serializer.rb
@@ -1,6 +1,6 @@
 class Api::V1::PullRequestSerializer < ActiveModel::Serializer
   attributes :id, :title, :repository_name, :owner_id, :html_url, :likes, :created_at,
-             :owner_name, :description, :commits, :owner_login
+             :owner_name, :description, :commits, :owner_login, :organization_id
   def likes
     return object.like_count if object.respond_to? :like_count
 


### PR DESCRIPTION
### Contexto
En la extensión de Froggo se quiere separar PRs por organización, pero actualmente no se puede obtener la organización de un PR.

### Qué se está haciendo
- Se agrega `organization_id` al serializer de `PullRequest`
- Se serializan los PRs en la llamada a `open_prs`