### PR TITLE
Show route for organizations

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -7,6 +7,10 @@ class Api::V1::OrganizationsController < Api::V1::BaseController
     respond_with github_user.organizations
   end
 
+  def show
+    respond_with organization
+  end
+
   def sync
     Github::OrganizationWebhookService.new(
       token: @github_session.token,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
         'github_users#organization_recommendation_statistics'
       get 'teams/:team_id/users/:github_login/recommendations' =>
         'github_users#team_review_recommendations'
-      resources :organizations, only: [:index] do
+      resources :organizations, only: [:index, :show] do
         resources :froggo_teams, only: [:index, :show, :create, :destroy, :update], shallow: true do
           get '/users' => 'github_users#froggo_team_users'
         end


### PR DESCRIPTION
### Contexto
Se necesitan los detalles de cada Organización para la extensión de froggo

### Qué se está haciendo
- Se habilita el `show` de `Organizations` en la api