### PR TITLE
F/add PR number to PR api serializer

### DIFF
--- a/app/serializers/api/v1/pull_request_serializer.rb
+++ b/app/serializers/api/v1/pull_request_serializer.rb
@@ -1,6 +1,6 @@
 class Api::V1::PullRequestSerializer < ActiveModel::Serializer
   attributes :id, :title, :repository_name, :owner_id, :html_url, :likes, :created_at,
-             :owner_name, :description, :commits, :owner_login, :organization_id
+             :owner_name, :description, :commits, :owner_login, :organization_id, :gh_number
   def likes
     return object.like_count if object.respond_to? :like_count
 


### PR DESCRIPTION
### Contexto
En el PR anterior se cambió el serializer que se usaba `open_prs`, pero quedó fuera este atributo

### Qué se está haciendo
- Se agrega el atributo `gh_number` a `PullRequestSerializer`