### PR TITLE
Feat/onboarding

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,9 +1,11 @@
 class OrganizationsController < ApplicationController
   layout 'application'
-  before_action :show_side_bar, only: [:link_organizations]
+  before_action :hide_sidebar, only: [:link_organizations]
+  before_action :show_sidebar, except: [:link_organizations]
   before_action :authenticate_github_user
   before_action :save_cookie_url
-  before_action :load_organization, except: [:index, :missing, :link_organizations]
+  before_action :load_organization, except: [:index, :missing, :link_organizations,
+                                             :tracked_organizations]
   before_action :ensure_organization_admin, only: :settings
 
   MONTH_LIMIT_DEFAULT = 9
@@ -43,6 +45,18 @@ class OrganizationsController < ApplicationController
   def settings
     @is_admin_github_session = github_session.session[:client_type] == "admin"
     @teams = froggo_teams
+  end
+
+  def tracked_organizations
+    @organizations = []
+    github_organizations.each do |github_organization|
+      organization = Organization.find_by(gh_id: github_organization[:id])
+      if organization
+        github_organization[:total_repositories] = total_repositories(organization)
+        github_organization[:tracked_repositories] = tracked_repositories(organization)
+        @organizations << github_organization
+      end
+    end
   end
 
   private
@@ -107,7 +121,19 @@ class OrganizationsController < ApplicationController
     github_session.save_froggo_path(request.fullpath)
   end
 
-  def show_side_bar
-    @show_side_bar = false
+  def hide_sidebar
+    @show_sidebar = false
+  end
+
+  def show_sidebar
+    @show_sidebar = true
+  end
+
+  def total_repositories(organization)
+    organization.repositories.count
+  end
+
+  def tracked_repositories(organization)
+    organization.repositories.count(&:tracked)
   end
 end

--- a/app/javascript/components/froggo-teams-list.vue
+++ b/app/javascript/components/froggo-teams-list.vue
@@ -71,7 +71,9 @@
           :src="user.attributes.avatarUrl"
         >
         <p class="ml-2 text-sm">
-          {{ $t('numberOfMembers', { 'membersLength': team.relationships.githubUsers.data.length }) }}
+          {{ $t('message.froggoTeams.numberOfMembers', {
+            'membersLength': team.relationships.githubUsers.data.length })
+          }}
         </p>
       </div>
     </div>

--- a/app/javascript/components/link-organizations.vue
+++ b/app/javascript/components/link-organizations.vue
@@ -83,7 +83,7 @@ export default {
       const body = { selectedOrganizations: this.selectedOrganizations };
       OrganizationsApi.createAll(body)
         .then(() => {
-          window.location.href = '/organizations';
+          window.location.href = '/tracked_organizations';
         }).catch(() => {
           this.error = true;
           this.errors = 'Ha ocurrido un error, inténtalo de nuevo';

--- a/app/javascript/components/tracked-organizations.vue
+++ b/app/javascript/components/tracked-organizations.vue
@@ -1,0 +1,98 @@
+<template>
+  <div
+    class="flex flex-col items-center"
+  >
+    <div
+      class="flex flex-col items-start w-full px-8 py-4 bg-blue-100"
+      v-if="organizationsWithoutTracking.length > 0"
+    >
+      <p
+        class="text-blue-500"
+      >
+        {{ $t('message.organization.organizationsWithoutTracking', {
+          organizationsWithoutTracking: organizationsWithoutTracking.length
+        }) }}
+      </p>
+      <ul
+        class="pl-10 text-blue-600 list-disc"
+      >
+        <li
+          v-for="organization in organizationsWithoutTracking"
+          :key="organization"
+        >
+          {{ organization.login }}
+        </li>
+      </ul>
+    </div>
+    <h1
+      class="flex flex-row flex-wrap w-full pl-10 mt-10 text-lg"
+    >
+      {{ $t('message.organization.myOrganizations') }}
+    </h1>
+    <div
+      class="flex flex-row flex-wrap w-full p-4 pl-10 "
+    >
+      <div
+        v-for="(organization) in organizations"
+        :key="organization.login"
+        class="w-2/5 p-4 m-4 border-2 border-solid rounded-lg border-slate-300"
+      >
+        <label
+          :for="organization.id"
+          class="flex items-center w-full"
+        >
+          <img
+            :src="organization.avatarUrl"
+            class="h-12 mr-4"
+          >
+          <a
+            v-if="organization.role==='admin'"
+            :href=" `/organizations/${organization.login}/settings`"
+            class="text-lg cursor-pointer"
+          >
+            {{ organization.login }}
+          </a>
+          <span
+            v-else
+            class="text-lg"
+          >{{ organization.login }} </span>
+          <span class="ml-auto text-sm">
+            {{ capitalizeRole(organization.role) }}
+          </span>
+        </label>
+        <span class="float-right text-sm text-gray-400">
+          {{ $t('message.organization.tracking', {
+            trackedRepositories: organization.trackedRepositories,
+            totalRepositories: organization.totalRepositories,
+          }) }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    organizations: {
+      type: Array,
+      required: true,
+    },
+  },
+  computed: {
+    organizationsWithoutTracking() {
+      return this.organizations.filter((organization) =>
+        organization.totalRepositories > 0 && organization.role === 'admin' && organization.trackedRepositories === 0,
+      );
+    },
+  },
+  methods: {
+    countUntrackedRepos(organization) {
+      return `${organization.trackedRepositories}/${organization.totalRepositories}`;
+    },
+    capitalizeRole(role) {
+      return role === 'admin' ? this.$t('message.froggoTeams.adminRole') : this.$t('message.froggoTeams.memberRole');
+    },
+  },
+};
+</script>

--- a/app/javascript/locales/en.js
+++ b/app/javascript/locales/en.js
@@ -127,6 +127,9 @@ export default {
         inactiveDays: 'Inactive days: ',
         score: 'Score: ',
       },
+      organizationsWithoutTracking: `You have {organizationsWithoutTracking} organizations where you are administrator
+      , but you haven't tracked any repository:`,
+      myOrganizations: 'My organizations',
     },
     recommendations: {
       recommendedReviewers: 'You should assign your next PR to...',

--- a/app/javascript/locales/es.js
+++ b/app/javascript/locales/es.js
@@ -133,6 +133,10 @@ export default {
         inactiveDays: 'Días inactivos: ',
         score: 'Puntaje: ',
       },
+      organizationsWithoutTracking: `Tienes {organizationsWithoutTracking} organizaciones donde eres
+      administrador, pero no trackeas ningún repositorio:`,
+      myOrganizations: 'Mis organizaciones',
+      tracking: 'Trackeando {trackedRepositories} / {totalRepositories} repositorios',
     },
     recommendations: {
       recommendedReviewers: 'Deberías mandar tu próximo PR a...',

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -48,6 +48,7 @@ import UserTags from '../components/profile/user-tags.vue';
 import TeamTagsContainer from '../components/profile/team-tags-container.vue';
 import LinkOrganizations from '../components/link-organizations.vue';
 import MultiCheckboxOrganizations from '../components/multi-checkbox-organizations.vue';
+import trackedOrganizations from '../components/tracked-organizations.vue';
 
 import Locales from '../locales/locales.js';
 import store from '../store';
@@ -102,6 +103,7 @@ document.addEventListener('DOMContentLoaded', () => {
   Vue.component('team-tags-container', TeamTagsContainer);
   Vue.component('link-organizations', LinkOrganizations);
   Vue.component('multi-checkbox-organizations', MultiCheckboxOrganizations);
+  Vue.component('tracked-organizations', trackedOrganizations);
   Vue.use(VueClipboard);
 
   if (document.getElementById('app') !== null) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
         <froggo-header
           :user="<%= @github_session.user.to_json %>"
           :organizations="<%= @github_session.user.organizations.to_json %>"
-          organization-path="<%= link_organizations_path %>"
+          organization-path="<%= @github_session.user.organizations ? tracked_organizations_path : link_organizations_path %>"
           org-authenticate-path="<%= org_authenticate_path %>"
           close-session-path="<%= close_session_path %>"
         />

--- a/app/views/organizations/_settings_content.html.erb
+++ b/app/views/organizations/_settings_content.html.erb
@@ -1,6 +1,6 @@
 <div class="card-extended">
   <div class="card-extended__header">
-    <div class="card-extended__back" onclick="window.location.href='<%= organization_path(name: @github_organization[:login]) %>'">
+    <div class="card-extended__back" onclick="window.location.href='<%= tracked_organizations_path() %>'">
       <%= image_tag("back-arrow.svg", class: "card-extended__back-arrow") %>
       <div class="card-extended__back-message"><%= t('messages.settings.button_back') %></div>
     </div>

--- a/app/views/organizations/tracked_organizations.html.erb
+++ b/app/views/organizations/tracked_organizations.html.erb
@@ -1,0 +1,3 @@
+<tracked-organizations
+  :organizations="<%= @organizations.to_json %> | camelizeKeys">
+<tracked-organizations/>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
   end
 
   get 'link_organizations' => 'organizations#link_organizations'
+  get 'tracked_organizations' => 'organizations#tracked_organizations'
 
   resources :github_users do
     resources :froggo_teams, only: [:index], controller: 'froggo_teams'


### PR DESCRIPTION
## Qué se hizo
Se agrega la segunda vista de onboarding. En esta se muestran las organizaciones creadas/linkeadas con froggo y la cantidad de repositorios que se están trackeando.
Al hacer click sobre una organización de la cual se es admin, se accede a los settings de la organización donde se pueden configurar repositorios. 

Además se linkea la nueva vista de `tracked_organizations` al primer paso del onboarding en `link_organizations`
![Screenshot (110)](https://user-images.githubusercontent.com/69604538/159018094-dda8ea98-9a06-4a31-b19c-71d87a9774a3.png)


UPDATE
|antes|después|
|-|-|
|![image](https://user-images.githubusercontent.com/24324363/159944252-9c0c8cd8-5eac-49a8-b6aa-17a90eba6727.png)|![image](https://user-images.githubusercontent.com/24324363/159944021-0b8c92d6-78e8-4c22-a6f6-bad46de5a7e1.png)|